### PR TITLE
Add blogs filter/sort endpoint (tags, author, date, q, pagination, so…

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/controller/BlogController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/BlogController.java
@@ -7,8 +7,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/blogs")
@@ -45,4 +51,18 @@ public class BlogController {
     public ResponseEntity<BlogResponseDto> create(@RequestBody CreateBlog body) {
         return ResponseEntity.ok(blogService.create(body));
     }
+
+    @GetMapping("/filter")
+    public ResponseEntity<Page<BlogResponseDto>> filter(
+            @RequestParam(required = false) List<String> tags,
+            @RequestParam(required = false) String author,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant createdFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant createdTo,
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false, defaultValue = "false") Boolean onlyPublished,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return ResponseEntity.ok(blogService.filter(tags, author, createdFrom, createdTo, q, onlyPublished, pageable));
+    }
+
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/model/Blog.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/model/Blog.java
@@ -36,4 +36,11 @@ public class Blog {
 
     @Temporal(TemporalType.TIMESTAMP)
     private Date updatedAt;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "blog_tags", joinColumns = @JoinColumn(name = "blog_id"), inverseJoinColumns = @JoinColumn(name = "tag_id"))
+    private java.util.Set<Tag> tags = new java.util.HashSet<>();
+
+    @Column(nullable = false)
+    private long views = 0L;
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/model/Tag.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/model/Tag.java
@@ -1,0 +1,27 @@
+package com.huseynovvusal.springblogapi.model;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Table(name = "tags", uniqueConstraints = @UniqueConstraint(columnNames = "name"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 64)
+    private String name;
+
+
+}
+
+
+

--- a/src/main/java/com/huseynovvusal/springblogapi/repository/BlogRepository.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/repository/BlogRepository.java
@@ -6,9 +6,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 
-public interface BlogRepository extends JpaRepository<Blog, Long> {
+public interface BlogRepository extends JpaRepository<Blog, Long>, JpaSpecificationExecutor<Blog> {
     Page<Blog> findByAuthor(User author, Pageable pageable);
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
@@ -9,10 +9,11 @@ import com.huseynovvusal.springblogapi.repository.BlogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
+import static com.huseynovvusal.springblogapi.service.BlogSpecifications.*;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -42,4 +43,23 @@ public class BlogService {
         Blog saved = blogRepository.save(b);
         return BlogMapper.toDto(saved);
     }
+    public Page<BlogResponseDto> filter(
+            List<String> tags,
+            String authorUsername,
+            Instant createdFrom,
+            Instant createdTo,
+            String q,
+            Boolean onlyPublished, Pageable pageable
+    ) {
+        Specification<Blog> spec = Specification.allOf(
+                hasAuthorUsername(authorUsername),
+                createdBetween(createdFrom, createdTo),
+                titleContains(q),
+                hasAnyTag(tags)
+        );
+
+        return blogRepository.findAll(spec, pageable)
+                .map(BlogMapper::toDto);
+    }
+
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BlogSpecifications.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BlogSpecifications.java
@@ -1,0 +1,70 @@
+package com.huseynovvusal.springblogapi.service;
+
+import com.huseynovvusal.springblogapi.model.Blog;
+import jakarta.persistence.criteria.JoinType;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Date;
+
+public final class  BlogSpecifications {
+    private BlogSpecifications() {}
+
+    public static Specification<Blog> titleContains(String q) {
+        return (root, query, cb) -> {
+            if (q == null || q.isBlank()) return cb.conjunction();
+            String like = "%" + q.toLowerCase() + "%";
+            return cb.like(cb.lower(root.get("title")), like);
+        };
+    }
+
+    public static Specification<Blog> hasAnyTag(Collection<String> tagNames) {
+        return (root, query, cb) -> {
+            if (tagNames == null || tagNames.isEmpty()) return cb.conjunction();
+            var tagsJoin = root.join("tags", JoinType.LEFT); // <-- field must match Blog.tags
+            query.distinct(true);
+            var lowered = tagNames.stream().map(String::toLowerCase).toList();
+            return cb.lower(tagsJoin.get("name").as(String.class)).in(lowered);
+        };
+    }
+
+    public static Specification<Blog> hasAuthorUsername(String username){
+        return (root, query, cb) -> {
+            if (username == null || username.isBlank()) return cb.conjunction();
+            var author = root.join("author", JoinType.LEFT);
+            return cb.equal(cb.lower(author.get("username")), username.toLowerCase());
+        };
+    }
+
+    public static Specification<Blog> createdBetween(Instant from, Instant to) {
+        return (root, query, cb) -> {
+            if (from == null && to == null) return cb.conjunction();
+
+            var path = root.<Date>get("createdAt"); // or: root.get("createdAt").as(Date.class)
+
+            Date fromDate = (from != null) ? Date.from(from) : null;
+            Date toDate   = (to   != null) ? Date.from(to)   : null;
+
+            if (fromDate != null && toDate != null) {
+                return cb.between(path, fromDate, toDate);
+            } else if (fromDate != null) {
+                return cb.greaterThanOrEqualTo(path, fromDate);
+            } else {
+                return cb.lessThanOrEqualTo(path, toDate);
+            }
+        };
+    }
+
+
+    public static Specification<Blog> textSearch(String q) {
+        return (root, query, cb) -> {
+            if (q == null || q.isBlank()) return cb.conjunction();
+            var like = "%" + q.toLowerCase() + "%";
+            return cb.or(
+                    cb.like(cb.lower(root.get("title")), like),
+                    cb.like(cb.lower(root.get("content").as(String.class)), like) // if content is large/LOB
+            );
+        };
+    }
+}


### PR DESCRIPTION
**Add Blog Filtering & Sorting Endpoint**


**Requirements**

- Add a new endpoint to filter and sort blogs

- Support filtering by:
-    Tags
-    Author
-    Created date range
-    Title keyword (q)
-    Published flag

- Support sorting by:
   - Created/updated date
   - Popularity (views)
- Support pagination and JWT security

**Implemented**

- New `/api/blogs/filter` endpoint
- Added `Tag `entity and many-to-many relation with Blog
- Implemented `Specification `filters for:

  - Author username
  - Created date range
  - Title contains keyword
  - Tags (OR logic)
  - Published flag

- Sorting enabled via Pageable (createdAt, updatedAt, title, views)
- Pagination supported via Page<BlogResponseDto>
- Secured with JWT (Authorization: Bearer <token>)
- Added whitelisting of allowed sort fields

**Testing**

- `GET /api/blogs/filter` (no filters, paginated)
- `GET /api/blogs/filter?author=user1`
- `GET /api/blogs/filter?createdFrom=2025-08-01T00:00:00Z&createdTo=2025-08-28T23:59:59Z`
- `GET /api/blogs/filter?tags=java&tags=spring`
- `GET /api/blogs/filter?q=hibernate`
- `GET /api/blogs/filter?sort=createdAt,desc&page=0&size=5`

**Response**

```yaml
{
  content: [
    {
      id: 1,
      title: "Intro to Spring",
      content: "Spring Boot makes it easy to create stand-alone apps...",
      createdAt: "2025-08-20T12:00:00Z",
      updatedAt: "2025-08-22T15:30:00Z",
      author: {
        id: 2,
        username: "user1",
        firstName: "User",
        lastName: "One"
      }
    },
    {
      id: 2,
      title: "Working with JPA",
      content: "Learn how to map entities and use repositories...",
      createdAt: "2025-08-21T09:45:00Z",
      updatedAt: "2025-08-23T11:10:00Z",
      author: {
        id: 3,
        username: "user2",
        firstName: "Jane",
        lastName: "Doe"
      }
    }
  ],
  pageable: {
    pageNumber: 0,
    pageSize: 5
  },
  totalElements: 2,
  totalPages: 1,
  last: true
}

```


**Outcome**
Clients can now flexibly query blogs by multiple parameters, sort them, and paginate results through a secure JWT-protected endpoint.