### PR TITLE
Add-bookmark/favorite-system-for-blog-posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,41 @@ Welcome to **Spring Blog API**! This is a modern, secure, and scalable RESTful b
 Edit `src/main/resources/application.yml` to configure database and other settings.
 
 ## 📖 API Documentation
-API endpoints and documentation will be provided as development progresses.
+
+### 🔖 Bookmarks / Favorites
+
+Authenticated users can bookmark their favorite blog posts for quick access.
+
+#### Endpoints
+All requests require an `Authorization: Bearer <JWT>` header.
+
+- **Add bookmark** (idempotent)  
+  `POST /api/bookmarks/{blogId}`  
+  → `204 No Content`
+
+- **Check if bookmarked**  
+  `GET /api/bookmarks/check?blogId={blogId}`  
+  → `true | false`
+
+- **List my bookmarks** (paged)  
+  `GET /api/bookmarks?page=0&size=10&sort=createdAt,desc`  
+  → returns a page of `BlogResponseDto`
+
+- **Toggle bookmark**  
+  `POST /api/bookmarks/{blogId}/toggle`  
+  → `true` (added) or `false` (removed)
+
+- **Remove bookmark** (idempotent)  
+  `DELETE /api/bookmarks/{blogId}`  
+  → `204 No Content`
+
+#### Notes
+- Duplicate prevention is enforced by a unique database constraint `(user_id, blog_id)` and idempotent service logic.
+- The current user is resolved from the JWT claim `uid`.
+- Error codes:
+    - `401 Unauthorized` — missing/expired token
+    - `404 Not Found` — blog does not exist
+
 
 ## 🤝 Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/src/main/java/com/huseynovvusal/springblogapi/controller/BookmarkController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/BookmarkController.java
@@ -1,0 +1,42 @@
+package com.huseynovvusal.springblogapi.controller;
+
+import com.huseynovvusal.springblogapi.service.BookmarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/bookmarks")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @PostMapping("/{blogId}")
+    public ResponseEntity<Void> add(@PathVariable Long blogId) {
+        bookmarkService.addBookmark(blogId);  // your Option-A service
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{blogId}")
+    public ResponseEntity<Void> remove(@PathVariable Long blogId) {
+        bookmarkService.removeBookmark(blogId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/check")
+    public ResponseEntity<Boolean> isBookmarked(@RequestParam Long blogId) {
+        return ResponseEntity.ok(bookmarkService.isBookmarked(blogId));
+    }
+
+    @PostMapping("/{blogId}/toggle")
+    public ResponseEntity<Boolean> toggle(@PathVariable Long blogId) {
+        return ResponseEntity.ok(bookmarkService.toggle(blogId));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> list(@RequestParam(defaultValue = "0") int page,
+                                  @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(bookmarkService.listMyBookmarks(org.springframework.data.domain.PageRequest.of(page, size)));
+    }
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/filter/JwtAuthenticationFilter.java
@@ -1,31 +1,30 @@
 package com.huseynovvusal.springblogapi.filter;
 
+import com.huseynovvusal.springblogapi.security.UserPrincipal;
 import com.huseynovvusal.springblogapi.service.JwtService;
-import com.huseynovvusal.springblogapi.service.UserDetailsServiceImpl;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
-import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.List;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
-    private final UserDetailsServiceImpl userDetailsService;
     private final HandlerExceptionResolver handlerExceptionResolver;
 
     @Override
@@ -33,24 +32,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         try {
-            final String authHeader = request.getHeader("Authorization");
+            String authHeader = request.getHeader("Authorization");
             if (authHeader == null || !authHeader.startsWith("Bearer ")) {
                 filterChain.doFilter(request, response);
                 return;
             }
 
-            final String jwt = authHeader.substring(7);
-            final String username = jwtService.extractUsername(jwt);
+            String token = authHeader.substring(7);
 
-            if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                var userDetails = userDetailsService.loadUserByUsername(username);
-                if (jwtService.isTokenValid(jwt, userDetails)) {
-                    var authToken = new UsernamePasswordAuthenticationToken(
-                            userDetails, null, userDetails.getAuthorities());
-                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                    SecurityContextHolder.getContext().setAuthentication(authToken);
-                }
+            if (!jwtService.isTokenValid(token)) {
+                filterChain.doFilter(request, response);
+                return;
             }
+
+            if (SecurityContextHolder.getContext().getAuthentication() != null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            Long userId = jwtService.extractUserId(token);
+            String username = jwtService.extractUsername(token);
+            List<String> roles = jwtService.extractRoles(token);
+            var authorities = roles.stream().map(SimpleGrantedAuthority::new).toList();
+
+            var principal = new UserPrincipal(userId, username, authorities);
+            var authToken = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+            authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+
             filterChain.doFilter(request, response);
         } catch (Exception e) {
             log.debug("JWT filter caught exception: {}", e.getMessage());

--- a/src/main/java/com/huseynovvusal/springblogapi/model/Bookmark.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/model/Bookmark.java
@@ -1,0 +1,33 @@
+package com.huseynovvusal.springblogapi.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "bookmarks", uniqueConstraints = @UniqueConstraint(name = "uk_user_blog", columnNames = {"user_id","blog_id"}))
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Bookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_bookmark_user"))
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "blog_id", nullable = false, foreignKey = @ForeignKey(name = "fk_bookmark_blog"))
+    private Blog blog;
+
+    @CreationTimestamp
+    @Column(nullable = false,updatable = false)
+    private Instant createdAt;
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/repository/BookmarkRepository.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/repository/BookmarkRepository.java
@@ -1,0 +1,23 @@
+package com.huseynovvusal.springblogapi.repository;
+
+import com.huseynovvusal.springblogapi.model.Bookmark;
+import com.huseynovvusal.springblogapi.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.nio.channels.FileChannel;
+import java.util.Optional;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+        boolean existsByUser_IdAndBlog_Id(Long userId, Long blogId);
+
+        Optional<Bookmark> findByUser_IdAndBlog_Id(Long userId, Long blogId);
+
+        long deleteByUser_IdAndBlog_Id(Long userId, Long blogId);
+
+        Page<Bookmark> findAllByUser(User user, Pageable pageable);
+
+        Page<Bookmark> findAllByUser_Id(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/security/SecurityUtils.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/security/SecurityUtils.java
@@ -1,0 +1,38 @@
+package com.huseynovvusal.springblogapi.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public final class SecurityUtils {
+    private SecurityUtils() {}
+
+    public static Long currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal() == null) {
+            throw new IllegalStateException("No authenticated principal");
+        }
+        Object principal = auth.getPrincipal();
+
+        if (principal instanceof UserPrincipal up) {
+            return up.id();              // <-- record accessor
+        }
+        throw new IllegalStateException("Unexpected principal type: " + principal.getClass().getName());
+    }
+
+    public static String currentUsername() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal() == null) {
+            throw new IllegalStateException("No authenticated principal");
+        }
+        Object principal = auth.getPrincipal();
+
+        if (principal instanceof UserPrincipal up) {
+            return up.username();        // <-- record accessor
+        }
+        // Fallback: sometimes Spring sets principal to a String (username)
+        if (principal instanceof String s) {
+            return s;
+        }
+        throw new IllegalStateException("Unexpected principal type: " + principal.getClass().getName());
+    }
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/security/UserPrincipal.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/security/UserPrincipal.java
@@ -1,0 +1,36 @@
+package com.huseynovvusal.springblogapi.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+/**
+ * Lightweight principal stored in SecurityContext.
+ */
+public record UserPrincipal(
+        Long id,
+        String username,
+        Collection<? extends GrantedAuthority> authorities
+) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;   // <-- required method
+    }
+
+    @Override
+    public String getPassword() {
+        return null;          // not needed after login
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BookmarkService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BookmarkService.java
@@ -1,0 +1,81 @@
+package com.huseynovvusal.springblogapi.service;
+
+import com.huseynovvusal.springblogapi.dto.response.BlogResponseDto;
+import com.huseynovvusal.springblogapi.mapper.BlogMapper;
+import com.huseynovvusal.springblogapi.model.Blog;
+import com.huseynovvusal.springblogapi.model.Bookmark;
+import com.huseynovvusal.springblogapi.model.User;
+import com.huseynovvusal.springblogapi.repository.BlogRepository;
+import com.huseynovvusal.springblogapi.repository.BookmarkRepository;
+import com.huseynovvusal.springblogapi.security.SecurityUtils;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final BlogRepository blogRepository;
+    private final EntityManager entityManager;
+
+    @Transactional
+    public void addBookmark(Long blogId) {
+        Long userId = SecurityUtils.currentUserId();
+
+        if (bookmarkRepository.existsByUser_IdAndBlog_Id(userId, blogId)) {
+            return; // idempotent
+        }
+
+        Blog blog = blogRepository.findById(blogId)
+                .orElseThrow(() -> new IllegalArgumentException("Blog not found: " + blogId));
+
+        try {
+            User userRef = entityManager.getReference(User.class, userId); // no SELECT
+            bookmarkRepository.save(Bookmark.builder().user(userRef).blog(blog).build());
+        } catch (DataIntegrityViolationException ignoreOnRace) {
+            // unique (user_id, blog_id) guarantees no duplicates if concurrent
+        }
+    }
+
+    @Transactional
+    public void removeBookmark(Long blogId) {
+        Long userId = SecurityUtils.currentUserId();
+        bookmarkRepository.deleteByUser_IdAndBlog_Id(userId, blogId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isBookmarked(Long blogId) {
+        Long userId = SecurityUtils.currentUserId();
+        return bookmarkRepository.existsByUser_IdAndBlog_Id(userId, blogId);
+    }
+
+    @Transactional
+    public boolean toggle(Long blogId) {
+        Long userId = SecurityUtils.currentUserId();
+        if (bookmarkRepository.existsByUser_IdAndBlog_Id(userId, blogId)) {
+            bookmarkRepository.deleteByUser_IdAndBlog_Id(userId, blogId);
+            return false; // now unbookmarked
+        } else {
+            Blog blog = blogRepository.findById(blogId)
+                    .orElseThrow(() -> new IllegalArgumentException("Blog not found: " + blogId));
+            User userRef = entityManager.getReference(User.class, userId);
+            bookmarkRepository.save(Bookmark.builder().user(userRef).blog(blog).build());
+            return true; // now bookmarked
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Page<BlogResponseDto> listMyBookmarks(Pageable pageable) {
+        Long userId = SecurityUtils.currentUserId();
+        // If you also want newest first by default, ensure an index on (user_id, created_at DESC)
+        return bookmarkRepository.findAllByUser_Id(userId, pageable)
+                .map(Bookmark::getBlog)
+                .map(BlogMapper::toDto);
+    }
+}


### PR DESCRIPTION
**✨ Add Bookmark/Favorite System for Blog Posts
📌 Summary**

This PR introduces a bookmark/favorite system that allows authenticated users to bookmark blog posts for quick access later. It enhances user experience by making it easy to manage favorite content.

**✅ Implemented**

- **Entity & DB Layer**

  - New Bookmark entity with unique (user_id, blog_id) constraint to prevent duplicates.
  - Repository methods for existsByUser_IdAndBlog_Id, deleteByUser_IdAndBlog_Id, and findAllByUser_Id.

- **Service Layer**

  - BookmarkService with methods to add, remove, check, toggle, and list bookmarks.
  - Idempotent operations (safe to call multiple times).

- **API Endpoints**

  -   POST /api/bookmarks/{blogId} → Add bookmark
  -   GET /api/bookmarks/check?blogId={blogId} → Check if bookmarked
  -   GET /api/bookmarks?page=&size=&sort= → List current user’s bookmarks (paged)
  -   POST /api/bookmarks/{blogId}/toggle → Toggle bookmark on/off
  -   DELETE /api/bookmarks/{blogId} → Remove bookmark

- **JWT Integration**

  - User resolved via uid claim from JWT, no extra DB lookup.
  - Duplicate protection via DB + service logic.

-  **Documentation**

  - Added Bookmarks / Favorites section under ## 📖 API Documentation in README.md with usage examples.

**🧪 Tested**

  - Add bookmark → returns 204 No Content
  - Check bookmark → returns true
  - List bookmarks → returns expected blogs
  - Duplicate add → still 204, no duplicates
  - Toggle → switches between true/false
  - Remove → 204, idempotent

**🎯 Why**

This feature improves usability by letting users save favorite posts, prevents duplicates at the DB level, and exposes a clean, consistent API for clients.