### PR TITLE
Add admin role and endpoints for blocking/unblocking users

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/config/SecurityConfig.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.huseynovvusal.springblogapi.config;
 
 import com.huseynovvusal.springblogapi.filter.JwtAuthenticationFilter;
+import com.huseynovvusal.springblogapi.filter.BlockedUserFilter;
 import com.huseynovvusal.springblogapi.service.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -31,6 +32,7 @@ public class SecurityConfig {
 
     private final UserDetailsServiceImpl userDetailsService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final BlockedUserFilter blockedUserFilter;
 
     /**
      * Configures the security filter chain for HTTP requests.
@@ -51,14 +53,14 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(
                         req -> req
-                                .requestMatchers("/auth/**")
-                                .permitAll()
-                                .anyRequest()
-                                .authenticated()
+                                .requestMatchers("/auth/**").permitAll()
+                                .requestMatchers("/admin/**").hasRole("ADMIN")
+                                .anyRequest().authenticated()
                 )
                 .userDetailsService(userDetailsService)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(blockedUserFilter, JwtAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/huseynovvusal/springblogapi/controller/AdminController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/AdminController.java
@@ -1,0 +1,32 @@
+package com.huseynovvusal.springblogapi.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.huseynovvusal.springblogapi.dto.BlockUserRequest;
+import com.huseynovvusal.springblogapi.dto.BlockUserResponse;
+import com.huseynovvusal.springblogapi.service.UserService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    private static final Logger logger = LoggerFactory.getLogger(AuthenticationController.class);
+    private final UserService userService;
+
+    @PostMapping("block-user")
+    public ResponseEntity<BlockUserResponse> changeBlockStatus(@Valid @RequestBody BlockUserRequest request){
+        logger.info("Changing Block Status for: {}", request.getUsername());
+        BlockUserResponse response = userService.changeBlockStatus(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/controller/AdminController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/AdminController.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/admin")
 public class AdminController {
 
-    private static final Logger logger = LoggerFactory.getLogger(AuthenticationController.class);
+    private static final Logger logger = LoggerFactory.getLogger(AdminController.class);
     private final UserService userService;
 
     @PostMapping("block-user")

--- a/src/main/java/com/huseynovvusal/springblogapi/controller/BlogController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/BlogController.java
@@ -21,7 +21,7 @@ import java.util.List;
  * Supports CRUD operations and filtering based on tags, author, and creation date.
  */
 @RestController
-@RequestMapping("blogs")
+@RequestMapping("/blogs")
 @RequiredArgsConstructor
 public class BlogController {
 

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/BlockUserRequest.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/BlockUserRequest.java
@@ -7,12 +7,12 @@ import lombok.Data;
 @AllArgsConstructor
 public class BlockUserRequest {
     /**
-     * Desired username for the account.
+     * Username for the account.
      */
     private String username;
 
     /**
-     * Password chosen by the user.
+     * Indicates whether the user is blocked.
      */
     private Boolean isBlocked;
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/BlockUserRequest.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/BlockUserRequest.java
@@ -1,0 +1,18 @@
+package com.huseynovvusal.springblogapi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class BlockUserRequest {
+    /**
+     * Desired username for the account.
+     */
+    private String username;
+
+    /**
+     * Password chosen by the user.
+     */
+    private Boolean isBlocked;
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/BlockUserResponse.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/BlockUserResponse.java
@@ -19,7 +19,7 @@ public class BlockUserResponse {
     private String lastName;
 
     /**
-     * Desired username for the account.
+     * Username for the account.
      */
     private String username;
 
@@ -29,7 +29,7 @@ public class BlockUserResponse {
     private String email;
 
     /**
-     * Password chosen by the user.
+     * Indicates whether the user account is blocked.
      */
     private Boolean isBlocked;
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/BlockUserResponse.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/BlockUserResponse.java
@@ -1,0 +1,35 @@
+package com.huseynovvusal.springblogapi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BlockUserResponse {
+    /**
+     * First name of the user.
+     */
+    private String firstName;
+
+    /**
+     * Last name of the user.
+     */
+    private String lastName;
+
+    /**
+     * Desired username for the account.
+     */
+    private String username;
+
+    /**
+     * Email address of the user.
+     */
+    private String email;
+
+    /**
+     * Password chosen by the user.
+     */
+    private Boolean isBlocked;
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/filter/BlockedUserFilter.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/filter/BlockedUserFilter.java
@@ -1,0 +1,40 @@
+package com.huseynovvusal.springblogapi.filter;
+
+import com.huseynovvusal.springblogapi.model.User;
+import com.huseynovvusal.springblogapi.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class BlockedUserFilter extends OncePerRequestFilter {
+
+    private final UserService userService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated() && !"anonymousUser".equals(authentication.getPrincipal())) {
+            String username = authentication.getName();
+            User user = userService.getUserByUsername(username);
+            if (user != null && user.isBlocked()) {
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                response.setContentType("application/json");
+                response.getWriter().write("{\"error\": \"User is blocked\"}");
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/model/User.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/model/User.java
@@ -55,6 +55,12 @@ public class User {
     private String password;
 
     /**
+     * Indicates whether the user account is blocked.
+     */
+    @Column(nullable = false)
+    private boolean isBlocked = false;
+
+    /**
      * Role assigned to the user (e.g., USER, ADMIN).
      */
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/huseynovvusal/springblogapi/service/UserService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/UserService.java
@@ -7,7 +7,6 @@ import com.huseynovvusal.springblogapi.dto.BlockUserRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.cglib.core.Block;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -57,10 +56,6 @@ public class UserService {
 
     public BlockUserResponse changeBlockStatus(BlockUserRequest request) {
         User user = getUserByUsername(request.getUsername());
-        if (user == null) {
-            log.error("User not found with username: {}", request.getUsername());
-            throw new UsernameNotFoundException("User not found: " + request.getUsername());
-        }
         user.setBlocked(request.getIsBlocked());
         userRepository.save(user);
         BlockUserResponse response = new BlockUserResponse();

--- a/src/main/java/com/huseynovvusal/springblogapi/service/UserService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/UserService.java
@@ -2,8 +2,12 @@ package com.huseynovvusal.springblogapi.service;
 
 import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.UserRepository;
+import com.huseynovvusal.springblogapi.dto.BlockUserResponse;
+import com.huseynovvusal.springblogapi.dto.BlockUserRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.cglib.core.Block;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -25,8 +29,13 @@ public class UserService {
      * @throws UsernameNotFoundException if the user is not found
      */
     public User getCurrentUser() {
-        String username = SecurityContextHolder.getContext().getAuthentication().getName();
-        log.debug("[UserService] Current username: {}", username);
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getName())) {
+            log.error("[UserService] No authenticated user found.");
+            throw new UsernameNotFoundException("No authenticated user found");
+        }
+        String username = authentication.getName();
+        log.info("[UserService] Current username: {}", username);
         return getUserByUsername(username);
     }
 
@@ -44,5 +53,23 @@ public class UserService {
             throw new UsernameNotFoundException("User not found: " + username);
         }
         return user;
+    }
+
+    public BlockUserResponse changeBlockStatus(BlockUserRequest request) {
+        User user = getUserByUsername(request.getUsername());
+        if (user == null) {
+            log.error("User not found with username: {}", request.getUsername());
+            throw new UsernameNotFoundException("User not found: " + request.getUsername());
+        }
+        user.setBlocked(request.getIsBlocked());
+        userRepository.save(user);
+        BlockUserResponse response = new BlockUserResponse();
+        response.setFirstName(user.getFirstName());
+        response.setLastName(user.getLastName());
+        response.setEmail(user.getEmail());
+        response.setUsername(user.getUsername());
+        response.setIsBlocked(user.isBlocked());
+        log.info("User {} has been {}", user.getUsername(), user.isBlocked() ? "blocked" : "unblocked");
+        return response;
     }
 }

--- a/src/test/java/com/huseynovvusal/springblogapi/service/UserServiceTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/service/UserServiceTest.java
@@ -1,0 +1,84 @@
+package com.huseynovvusal.springblogapi.service;
+
+import com.huseynovvusal.springblogapi.dto.BlockUserRequest;
+import com.huseynovvusal.springblogapi.dto.BlockUserResponse;
+import com.huseynovvusal.springblogapi.model.User;
+import com.huseynovvusal.springblogapi.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        userService = new UserService(userRepository);
+    }
+
+    @Test
+    void should_block_user_when_requested() {
+        // Given
+        String username = "user1";
+        User user = new User();
+        user.setUsername(username);
+        user.setBlocked(false);
+
+        when(userRepository.findByUsername(username)).thenReturn(user);
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        // When
+        BlockUserRequest request = new BlockUserRequest(username, true);
+        BlockUserResponse response = userService.changeBlockStatus(request);
+
+        // Then
+        assertTrue(response.getIsBlocked());
+        assertThat(response.getUsername()).isEqualTo(username);
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void should_unblock_user_when_requested() {
+        // Given
+        String username = "user2";
+        User user = new User();
+        user.setUsername(username);
+        user.setBlocked(true);
+
+        when(userRepository.findByUsername(username)).thenReturn(user);
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        // When
+        BlockUserRequest request = new BlockUserRequest(username, false);
+        BlockUserResponse response = userService.changeBlockStatus(request);
+
+        // Then
+        assertFalse(response.getIsBlocked());
+        assertThat(response.getUsername()).isEqualTo(username);
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void should_throw_when_user_not_found() {
+        // Given
+        String username = "notfound";
+        when(userRepository.findByUsername(username)).thenReturn(null);
+
+        // When & Then
+        BlockUserRequest request = new BlockUserRequest(username, true);
+        assertThrows(UsernameNotFoundException.class, () -> userService.changeBlockStatus(request));
+    }
+}

--- a/src/test/java/com/huseynovvusal/springblogapi/service/UserServiceTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/service/UserServiceTest.java
@@ -6,8 +6,10 @@ import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
@@ -15,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
     @Mock


### PR DESCRIPTION
## Feature: Admin User Blocking/Unblocking | Fixes #41 
This pull request introduces support for admin-level user management, specifically the ability for admins to block or unblock users.

### Key Changes:
- Added logic to ensure only users with the ADMIN role can perform sensitive user management actions.
- Implemented [changeBlockStatus] in [UserService] to allow blocking and unblocking users.
- Returns a detailed response with user info and block status.
- Improved error handling and logging for user lookup by username and for the currently authenticated user.
Security:
- Ensures only authenticated and authorized users can perform block/unblock actions.
- Filter added to access endpoints based on isBlocked flag in User Entity Class
- Added supporting test scenarios.

### Summary
These changes lay the groundwork for admin user management endpoints and ensure that user blocking/unblocking is secure, auditable, and robust.