### PR TITLE
Add Swagger/OpenAPI Documentation with springdoc-openapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,32 +51,11 @@ Edit `src/main/resources/application.yml` to configure database and other settin
 
 ## 📖 API Documentation
 
-### 🔖 Bookmarks / Favorites
+Interactive API documentation is available via Swagger UI.  
+**Most requests require an `Authorization: Bearer <JWT>` header.**
 
-Authenticated users can bookmark their favorite blog posts for quick access.
+**`http://localhost:8082/api/v1/swagger-ui/index.html#/`**
 
-#### Endpoints
-All requests require an `Authorization: Bearer <JWT>` header.
-
-- **Add bookmark** (idempotent)  
-  `POST /api/bookmarks/{blogId}`  
-  → `204 No Content`
-
-- **Check if bookmarked**  
-  `GET /api/bookmarks/check?blogId={blogId}`  
-  → `true | false`
-
-- **List my bookmarks** (paged)  
-  `GET /api/bookmarks?page=0&size=10&sort=createdAt,desc`  
-  → returns a page of `BlogResponseDto`
-
-- **Toggle bookmark**  
-  `POST /api/bookmarks/{blogId}/toggle`  
-  → `true` (added) or `false` (removed)
-
-- **Remove bookmark** (idempotent)  
-  `DELETE /api/bookmarks/{blogId}`  
-  → `204 No Content`
 
 #### Notes
 - Duplicate prevention is enforced by a unique database constraint `(user_id, blog_id)` and idempotent service logic.

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/huseynovvusal/springblogapi/config/OpenAPIConfiguration.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/config/OpenAPIConfiguration.java
@@ -1,0 +1,26 @@
+package com.huseynovvusal.springblogapi.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenAPIConfiguration {
+    @Bean
+    public OpenAPI defineOpenApi() {
+        Server server = new Server();
+        server.setUrl("http://localhost:8082");
+        server.setDescription("Development");
+
+        Info information = new Info()
+                .title("Spring Blog API")
+                .version("1.0")
+                .description("Find all API enpoints and related info here...");
+        return new OpenAPI().info(information).servers(List.of(server));
+    }
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/config/SecurityConfig.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         req -> req
                                 .requestMatchers("/auth/**").permitAll()
+                                .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
                                 .requestMatchers("/admin/**").hasRole("ADMIN")
                                 .anyRequest().authenticated()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,9 @@ security:
 client:
   app:
     url: ${CLIENT_APP_URL:http://localhost:3000}
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
## Description:
This PR addresses the lack of API documentation by integrating Swagger UI using [springdoc-openapi]. With this addition:
- Developers and API consumers can now explore and test all endpoints interactively.
- The OpenAPI specification is generated automatically from the codebase, ensuring up-to-date documentation.
- The Swagger UI is available at: [http://localhost:8082/api/v1/swagger-ui/index.html#/]

### Key changes:
- Added springdoc-openapi-starter-webmvc-ui dependency for Spring Boot 3.x compatibility.
- Updated security configuration to allow public access to Swagger UI and OpenAPI endpoints.
- Updated [README.md] with instructions and a direct link to the API documentation.

This enhancement makes it easier for developers and consumers to understand available endpoints, request/response formats, and parameters and **Fixes #3**.