### PR TITLE
Add @Size validation to blog content in CreateBlog DTO

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/dto/CreateBlog.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/CreateBlog.java
@@ -26,5 +26,6 @@ public class CreateBlog {
      * Content/body of the blog post.
      */
     @NotBlank(message = "Content is required")
+    @Size(max = 50000, message = "Content must not exceed 50,000 characters")
     private String content;
 }


### PR DESCRIPTION
Added @Size validation to the content field in CreateBlog DTO to prevent excessively large input.

Fixes #65