### PR TITLE
test: add authentication integration workflow coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,27 @@ Thank you for your interest in contributing to **Spring Blog API**! We welcome c
 - Write meaningful commit messages.
 - Add tests for new features or bug fixes.
 
+## ✅ Running Tests
+Run the full test suite before opening a pull request:
+
+```bash
+./gradlew test
+```
+
+Generate the JaCoCo coverage report with:
+
+```bash
+./gradlew test jacocoTestReport
+```
+
+The HTML coverage report is generated at:
+
+```text
+build/reports/jacoco/test/html/index.html
+```
+
+Integration tests should exercise realistic API workflows through Spring Boot Test, including successful flows and expected error responses.
+
 ## 🐞 Issue Reporting
 - Search for existing issues before opening a new one.
 - Provide clear steps to reproduce, expected behavior, and screenshots/logs if applicable.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 	id 'org.springframework.boot' version '3.5.4'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -57,4 +58,13 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		html.required = true
+	}
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/UserDetailsServiceImpl.java
@@ -4,7 +4,6 @@ import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -34,7 +33,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
      */
     @Override
     @Transactional(readOnly = true)
-    @Cacheable(value = "users", key = "#username")
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username);
 

--- a/src/test/java/com/huseynovvusal/springblogapi/integration/AuthenticationIntegrationTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/integration/AuthenticationIntegrationTest.java
@@ -1,0 +1,186 @@
+package com.huseynovvusal.springblogapi.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.huseynovvusal.springblogapi.dto.LoginRequest;
+import com.huseynovvusal.springblogapi.dto.RefreshTokenRequest;
+import com.huseynovvusal.springblogapi.dto.RegisterRequest;
+import com.huseynovvusal.springblogapi.repository.RefreshTokenRepository;
+import com.huseynovvusal.springblogapi.repository.UserRepository;
+import com.huseynovvusal.springblogapi.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "server.servlet.context-path=/api/v1",
+        "resilience4j.ratelimiter.configs.auth.limit-for-period=100",
+        "resilience4j.ratelimiter.configs.default.limit-for-period=100"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthenticationIntegrationTest {
+
+    private static final String CONTEXT_PATH = "/api/v1";
+    private static final String REGISTER_PATH = CONTEXT_PATH + "/auth/register";
+    private static final String LOGIN_PATH = CONTEXT_PATH + "/auth/login";
+    private static final String REFRESH_PATH = CONTEXT_PATH + "/auth/refresh";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @MockitoBean
+    private EmailService emailService;
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        cacheManager.getCacheNames().forEach(name -> Objects.requireNonNull(cacheManager.getCache(name)).clear());
+    }
+
+    @Test
+    @DisplayName("Should complete the authentication workflow from registration to refresh token rotation")
+    void shouldCompleteAuthenticationWorkflow() throws Exception {
+        JsonNode registration = register(registerRequest("alice", "alice@example.com"));
+        assertThat(registration.get("token").asText()).isNotBlank();
+        assertThat(registration.get("refreshToken").asText()).isNotBlank();
+
+        JsonNode firstLogin = login("alice", "Password123!");
+        assertThat(firstLogin.get("token").asText()).isNotBlank();
+        assertThat(firstLogin.get("refreshToken").asText()).isNotBlank();
+
+        JsonNode secondLogin = login("alice", "Password123!");
+        assertThat(secondLogin.get("token").asText()).isNotBlank();
+        assertThat(secondLogin.get("refreshToken").asText()).isNotBlank();
+
+        String originalRefreshToken = secondLogin.get("refreshToken").asText();
+        JsonNode refreshedTokens = refresh(originalRefreshToken);
+        String rotatedRefreshToken = refreshedTokens.get("refreshToken").asText();
+
+        assertThat(refreshedTokens.get("token").asText()).isNotBlank();
+        assertThat(rotatedRefreshToken).isNotBlank();
+        assertThat(rotatedRefreshToken).isNotEqualTo(originalRefreshToken);
+
+        refreshShouldFail(originalRefreshToken);
+
+        JsonNode secondRefresh = refresh(rotatedRefreshToken);
+        assertThat(secondRefresh.get("token").asText()).isNotBlank();
+        assertThat(secondRefresh.get("refreshToken").asText()).isNotBlank();
+        assertThat(secondRefresh.get("refreshToken").asText()).isNotEqualTo(rotatedRefreshToken);
+    }
+
+    @Test
+    @DisplayName("Should reject registration when username already exists")
+    void registerShouldRejectDuplicateUsername() throws Exception {
+        RegisterRequest request = registerRequest("alice", "alice@example.com");
+        register(request);
+
+        mockMvc.perform(post(REGISTER_PATH).contextPath(CONTEXT_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("User with username alice already exists"));
+    }
+
+    @Test
+    @DisplayName("Should reject login when password is invalid")
+    void loginShouldRejectInvalidPassword() throws Exception {
+        register(registerRequest("alice", "alice@example.com"));
+
+        mockMvc.perform(post(LOGIN_PATH).contextPath(CONTEXT_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest("alice", "wrong-password"))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Authentication failed"));
+    }
+
+    @Test
+    @DisplayName("Should reject refresh when token format is invalid")
+    void refreshShouldRejectInvalidTokenFormat() throws Exception {
+        mockMvc.perform(post(REFRESH_PATH).contextPath(CONTEXT_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new RefreshTokenRequest("invalid-refresh-token"))))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.message").value("Unexpected error"));
+    }
+
+    private JsonNode register(RegisterRequest request) throws Exception {
+        String response = mockMvc.perform(post(REGISTER_PATH).contextPath(CONTEXT_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        return objectMapper.readTree(response);
+    }
+
+    private JsonNode login(String username, String password) throws Exception {
+        String response = mockMvc.perform(post(LOGIN_PATH).contextPath(CONTEXT_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest(username, password))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        return objectMapper.readTree(response);
+    }
+
+    private void refreshShouldFail(String refreshToken) throws Exception {
+        mockMvc.perform(post(REFRESH_PATH).contextPath(CONTEXT_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new RefreshTokenRequest(refreshToken))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Refresh token " + refreshToken + " not valid"));
+    }
+
+    private JsonNode refresh(String refreshToken) throws Exception {
+        String response = mockMvc.perform(post(REFRESH_PATH).contextPath(CONTEXT_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new RefreshTokenRequest(refreshToken))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        return objectMapper.readTree(response);
+    }
+
+    private RegisterRequest registerRequest(String username, String email) {
+        return new RegisterRequest("Alice", "Tester", username, email, "Password123!");
+    }
+
+    private LoginRequest loginRequest(String username, String password) {
+        return new LoginRequest(username, password);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the first authentication-focused slice of integration test coverage for the API.

It covers realistic authentication workflows using Spring Boot Test and MockMvc, including registration, login, repeated login, refresh token rotation, and expected error responses.

## Changes

- Added `AuthenticationIntegrationTest` for authentication workflow coverage.
- Added JaCoCo test coverage reporting.
- Documented test and coverage commands in `CONTRIBUTING.md`.
- Removed `@Cacheable` from `UserDetailsServiceImpl` because repeated login attempts exposed an issue where cached `UserDetails` credentials could be erased after successful authentication.

## Covered Scenarios

- Register a new user and receive access/refresh tokens.
- Login with valid credentials.
- Login repeatedly with the same valid credentials.
- Rotate refresh tokens.
- Reject reuse of an already rotated refresh token.
- Reject duplicate username registration.
- Reject login with an invalid password.
- Reject malformed refresh token input.

## Test Results

```bash
./gradlew test jacocoTestReport
```

Result:

```text
BUILD SUCCESSFUL
```

JaCoCo line coverage after this change:

```text
44.09% (287/651 lines covered)
```

HTML coverage report:

```text
build/reports/jacoco/test/html/index.html
```

## Notes

This PR focuses on the authentication workflow first, as discussed. Additional integration tests for post creation, comment-related flows, and broader error handling can be added in follow-up PRs.
