### PR TITLE
Add Feature/support rich text

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+	// XSS prevention
+	implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20260102.1'
+
     // Caching
     implementation 'org.springframework.boot:spring-boot-starter-cache'
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/security/RichTextSanitizer.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/security/RichTextSanitizer.java
@@ -4,6 +4,15 @@ import org.springframework.stereotype.Component;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
 
+/**
+ * Utility class for sanitizing user-provided rich text content to prevent XSS attacks.
+ * Uses the OWASP Java HTML Sanitizer to strip disallowed tags and attributes.
+ * Disallowed tags are removed while preserving safe textual content when possible.
+ * 
+ * Allowed elements: p, br, b, strong, i, em, ul, ol, li, blockquote, pre, a
+ * Allowed on links: href (http/https only), rel="nofollow" enforced automatically.
+ * 
+ */
 @Component
 public class RichTextSanitizer {
     private static final PolicyFactory policy = new HtmlPolicyBuilder()
@@ -13,6 +22,13 @@ public class RichTextSanitizer {
     .requireRelNofollowOnLinks()
     .toFactory();
 
+    /**
+     * Returns sanitized HTML, or null if input is null.
+     * All tags and attributes not in the policy are stripped.
+     *
+     * @param content raw HTML string to sanitize
+     * @return sanitized HTML, or null if content is null
+     */
     public String sanitize(String content){
         if (content!=null) {
             return policy.sanitize(content);

--- a/src/main/java/com/huseynovvusal/springblogapi/security/RichTextSanitizer.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/security/RichTextSanitizer.java
@@ -1,0 +1,22 @@
+package com.huseynovvusal.springblogapi.security;
+
+import org.springframework.stereotype.Component;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+
+@Component
+public class RichTextSanitizer {
+    private static final PolicyFactory policy = new HtmlPolicyBuilder()
+    .allowElements("p", "br", "b", "strong", "i", "em", "ul", "ol", "li", "blockquote", "a", "pre")
+    .allowAttributes("href").onElements("a")
+    .allowUrlProtocols("http", "https")
+    .requireRelNofollowOnLinks()
+    .toFactory();
+
+    public String sanitize(String content){
+        if (content!=null) {
+            return policy.sanitize(content);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
@@ -6,6 +6,8 @@ import com.huseynovvusal.springblogapi.mapper.BlogMapper;
 import com.huseynovvusal.springblogapi.model.Blog;
 import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.BlogRepository;
+import com.huseynovvusal.springblogapi.security.RichTextSanitizer;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -32,6 +34,7 @@ public class BlogService {
 
     private final BlogRepository blogRepository;
     private final UserService userService;
+    private final RichTextSanitizer richTextSanitizer;
 
     /**
      * Retrieves all blogs with pagination.
@@ -90,7 +93,12 @@ public class BlogService {
 
         Blog blog = new Blog();
         blog.setTitle(request.getTitle());
-        blog.setContent(request.getContent());
+        String sanitized = richTextSanitizer.sanitize(request.getContent());
+        if (!sanitized.equals(request.getContent())) {
+            log.info("Content sanitized for user {}", currentUser.getUsername());
+        }
+
+        blog.setContent(sanitized);
         blog.setAuthor(currentUser);
 
         Blog saved = blogRepository.save(blog);

--- a/src/test/java/com/huseynovvusal/springblogapi/security/RichTextSanitizerTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/security/RichTextSanitizerTest.java
@@ -1,0 +1,68 @@
+package com.huseynovvusal.springblogapi.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+class RichTextSanitizerTest {
+
+    private final RichTextSanitizer sanitizer = new RichTextSanitizer();
+
+    @Test
+    void should_remove_script_tag(){
+        String raw = "<script>alert('XSS')</script>";
+        String sanitized = sanitizer.sanitize(raw);
+
+        assertFalse(sanitized.contains("<script>"));
+    }
+
+    @Test
+    void should_remove_nested_script_tag(){
+        String raw = "<scr<script>ipt>alert('xss')</scr<script>ipt>";
+        String sanitized = sanitizer.sanitize(raw);
+        
+        assertFalse(sanitized.contains("<script>"));
+    }
+
+    @Test
+    void should_remove_capital_script_tag(){
+        String raw = "<SCRIPT>alert('XSS')</SCRIPT>";
+        String sanitized = sanitizer.sanitize(raw);
+
+        assertFalse(sanitized.contains("<SCRIPT>"));
+    }
+
+    @Test
+    void should_remove_javascript_link(){
+        String raw = "<a href=\"javascript:alert('xss')\">clique</a>";
+        String sanitized = sanitizer.sanitize(raw);
+
+        assertFalse(sanitized.contains("javascript"));
+    }
+
+    @Test
+    void should_preserve_content(){
+        String raw = "<b>Hello</b> <i>World</i>";
+        String sanitized = sanitizer.sanitize(raw);
+
+        assertEquals(raw, sanitized);
+    }
+
+    @Test
+    void should_preserve_link(){
+        String raw = "<a href=\"https://google.com\">Google</a>";
+        String sanitized = sanitizer.sanitize(raw);
+
+        assertTrue(sanitized.contains("<a href=\"https://google.com\" rel=\"nofollow\">Google</a>"));
+    }
+
+    @Test
+    void should_remove_img(){
+        String raw = "<img src=x onerror=alert(1)>";
+        String sanitized = sanitizer.sanitize(raw);
+
+        assertFalse(sanitized.contains("<img"));
+        assertFalse(sanitized.contains("onerror"));
+    }
+}


### PR DESCRIPTION
This PR adds safe rich text sanitization for blog post content using OWASP Java HTML Sanitizer. Fixes #12 
The sanitizer allows common formatting tags while removing potentially dangerous HTML and XSS vectors before content is persisted.

## Changes
- Add a `RichTextSanitizer` component using OWASP Java HTML Sanitizer
- Sanitize blog post content
- Allow safe rich text formatting (bold, italics, lists, links, etc.)
- Block potentially dangerous HTML and XSS vectors
- Add unit tests covering common XSS payloads and allowed formatting

## Supported formatting

Allowed HTML elements:  `p`, `br`, `b`, `strong`,  `i`, `em`, `ul`, `ol`, `li`, `blockquote`, `a`, `pre`

Security restrictions:
- Removes `<script>` tags
- Removes inline event handlers (`onclick`, `onerror`, etc.)
- Blocks `javascript:` URLs
- Allows only `http` and `https` links
- Disallows images, iframes, and embedded content

## How to test?
```
./gradlew test --tests RichTextSanitizerTest
or manually through the Swagger
```