### PR TITLE
feat: add blog search functionality with title, content, and tag supportFeat/blog search api

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/controller/BlogController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/BlogController.java
@@ -5,6 +5,7 @@ import com.huseynovvusal.springblogapi.dto.response.BlogResponseDto;
 import com.huseynovvusal.springblogapi.service.BlogService;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,4 +113,24 @@ public class BlogController {
                 tags, author, createdFrom, createdTo, q, onlyPublished);
         return blogService.filter(tags, author, createdFrom, createdTo, q, onlyPublished, pageable);
     }
+
+    /**
+    * Searches blogs by keyword in title, content, or tags.
+    *
+    * @param q search keyword
+    * @param pageable pagination information
+    * @return paginated list of matching blogs
+    */
+    @Operation(
+    summary = "Search blog posts",
+    description = "Search blogs by title, content or tags"
+    )
+    @GetMapping("/search")
+    public Page<BlogResponseDto> search(
+        @RequestParam String q,
+        @PageableDefault(size = 20) Pageable pageable) {
+
+    logger.info("Searching blogs with keyword: {}", q);
+    return blogService.search(q, pageable);
+  }
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
@@ -149,8 +149,7 @@ public class BlogService {
    public Page<BlogResponseDto> search(String q, Pageable pageable) {
     log.debug("Searching blogs with keyword: {}", q);
        Specification<Blog> spec =
-            Specification.where(titleContains(q))
-                    .or(contentContains(q))
+            Specification.where(textSearch(q))
                     .or(tagContains(q));
      return blogRepository
             .findAll(spec, pageable)

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
@@ -133,4 +133,28 @@ public class BlogService {
 
         return blogRepository.findAll(spec, pageable).map(BlogMapper::toDto);
     }
+
+    /**
+    * Searches blogs based on a keyword present in title, content, or tags.
+    * Supports pagination and caching for better performance.
+    *
+    * @param q search keyword
+    * @param pageable pagination and sorting information
+    * @return paginated list of matching blog responses
+    */
+    @Cacheable(
+        value = "searchBlogs",
+        key = "{#q,#pageable.pageNumber,#pageable.pageSize}"
+   )
+   public Page<BlogResponseDto> search(String q, Pageable pageable) {
+    log.debug("Searching blogs with keyword: {}", q);
+       Specification<Blog> spec =
+            Specification.where(titleContains(q))
+                    .or(contentContains(q))
+                    .or(tagContains(q));
+     return blogRepository
+            .findAll(spec, pageable)
+            .map(BlogMapper::toDto);
+    }
+
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BlogSpecifications.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BlogSpecifications.java
@@ -100,4 +100,25 @@ public final class BlogSpecifications {
             );
         };
     }
+
+    /**
+    * Creates a specification to search blogs by tag name.
+    *
+    * @param q keyword used for tag search
+    * @return specification matching tags containing the keyword
+    */
+    public static Specification<Blog> tagContains(String q) {
+    return (root, query, cb) -> {
+        if (q == null || q.isBlank()) {
+            return cb.conjunction();
+        }
+
+        query.distinct(true);
+
+        return cb.like(
+                cb.lower(root.join("tags", JoinType.LEFT).get("name")),
+                "%" + q.toLowerCase() + "%"
+        );
+    };
+   }
 }


### PR DESCRIPTION
Implemented search functionality for blog posts with support for title, content, and tag-based queries.

Changes:
- Added /blogs/search API endpoint
- Added pagination support for search results
- Added Swagger documentation using @Operation
- Reused existing textSearch() for title and content matching
- Added tagContains() specification for tag-based searching
- Added caching for search results