### PR TITLE
fix(docker): replace invalid env variable syntax in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
       - SPRING_DATASOURCE_PASSWORD=postgres
       - SPRING_MAIL_HOST=mailhog
       - SPRING_MAIL_PORT=1025
-      - SPRING_MAIL_USERNAME:mailuser
-      - SPRING_MAIL_PASSWORD:mailpass
+      - SPRING_MAIL_USERNAME=mailuser
+      - SPRING_MAIL_PASSWORD=mailpass
 
 networks:
   default:


### PR DESCRIPTION
This PR fixes the environment variable syntax in docker-compose.yml.

Changed:

- SPRING_MAIL_USERNAME:mailuser
- SPRING_MAIL_PASSWORD:mailpass

to:

- SPRING_MAIL_USERNAME=mailuser
- SPRING_MAIL_PASSWORD=mailpass

This ensures proper parsing in Docker Compose list-style environment configuration.