### PR TITLE
Add max-length validation for firstName and lastName in RegisterRequest

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/dto/RegisterRequest.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/RegisterRequest.java
@@ -18,14 +18,12 @@ public class RegisterRequest {
 
   /** First name of the user. */
   @NotBlank(message = "First name is required")
-  @Size(min = 1, max = 50,
-      message = "First name must not exceed 50 characters")
+  @Size(min = 1, max = 50, message = "First name must not exceed 50 characters")
   private String firstName;
 
   /** Last name of the user. */
   @NotBlank(message = "Last name is required")
-  @Size(min = 1, max = 50,
-      message = "Last name must not exceed 50 characters")
+  @Size(min = 1, max = 50, message = "Last name must not exceed 50 characters")
   private String lastName;
 
   /** Desired username for the account. */

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/RegisterRequest.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/RegisterRequest.java
@@ -18,10 +18,14 @@ public class RegisterRequest {
 
   /** First name of the user. */
   @NotBlank(message = "First name is required")
+  @Size(min = 1, max = 50,
+      message = "First name must not exceed 50 characters")
   private String firstName;
 
   /** Last name of the user. */
   @NotBlank(message = "Last name is required")
+  @Size(min = 1, max = 50,
+      message = "Last name must not exceed 50 characters")
   private String lastName;
 
   /** Desired username for the account. */

--- a/src/test/java/com/huseynovvusal/springblogapi/integration/AuthenticationIntegrationTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/integration/AuthenticationIntegrationTest.java
@@ -94,6 +94,33 @@ class AuthenticationIntegrationTest {
     assertThat(secondRefresh.get("refreshToken").asText()).isNotEqualTo(rotatedRefreshToken);
   }
 
+@Test
+@DisplayName("Should reject registration when first name exceeds max length")
+void registerShouldRejectLongFirstName() throws Exception {
+
+  String longFirstName = "A".repeat(51);
+
+  RegisterRequest request =
+      new RegisterRequest(
+          longFirstName,
+          "Tester",
+          "alice",
+          "alice@example.com",
+          "Password123!");
+
+  mockMvc
+      .perform(
+          post(REGISTER_PATH)
+              .contextPath(CONTEXT_PATH)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("Validation failed"))
+      .andExpect(
+          jsonPath("$.fieldErrors.firstName")
+              .value("First name must not exceed 50 characters"));
+}
+
   @Test
   @DisplayName("Should reject registration when username already exists")
   void registerShouldRejectDuplicateUsername() throws Exception {

--- a/src/test/java/com/huseynovvusal/springblogapi/integration/AuthenticationIntegrationTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/integration/AuthenticationIntegrationTest.java
@@ -94,32 +94,26 @@ class AuthenticationIntegrationTest {
     assertThat(secondRefresh.get("refreshToken").asText()).isNotEqualTo(rotatedRefreshToken);
   }
 
-@Test
-@DisplayName("Should reject registration when first name exceeds max length")
-void registerShouldRejectLongFirstName() throws Exception {
+  @Test
+  @DisplayName("Should reject registration when first name exceeds max length")
+  void registerShouldRejectLongFirstName() throws Exception {
 
-  String longFirstName = "A".repeat(51);
+    String longFirstName = "A".repeat(51);
 
-  RegisterRequest request =
-      new RegisterRequest(
-          longFirstName,
-          "Tester",
-          "alice",
-          "alice@example.com",
-          "Password123!");
+    RegisterRequest request =
+        new RegisterRequest(longFirstName, "Tester", "alice", "alice@example.com", "Password123!");
 
-  mockMvc
-      .perform(
-          post(REGISTER_PATH)
-              .contextPath(CONTEXT_PATH)
-              .contentType(MediaType.APPLICATION_JSON)
-              .content(objectMapper.writeValueAsString(request)))
-      .andExpect(status().isBadRequest())
-      .andExpect(jsonPath("$.message").value("Validation failed"))
-      .andExpect(
-          jsonPath("$.fieldErrors.firstName")
-              .value("First name must not exceed 50 characters"));
-}
+    mockMvc
+        .perform(
+            post(REGISTER_PATH)
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("Validation failed"))
+        .andExpect(
+            jsonPath("$.fieldErrors.firstName").value("First name must not exceed 50 characters"));
+  }
 
   @Test
   @DisplayName("Should reject registration when username already exists")


### PR DESCRIPTION
Fixes #80

Changes:
- Added @Size(max = 50) validation to firstName
- Added @Size(max = 50) validation to lastName
- Existing validation behavior remains unchanged
- Validation errors return HTTP 400 through existing RestExceptionHandler

Verification:
- Ran ./gradlew test successfully