### PR TITLE
feat: add GET /users/me endpoint for authenticated user profile

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/controller/UserController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/UserController.java
@@ -18,35 +18,32 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "bearerAuth")
 public class UserController {
 
-    private static final Logger logger =
-            LoggerFactory.getLogger(UserController.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserController.class);
 
-    private final UserService userService;
+  private final UserService userService;
 
-    /**
-     * Retrieves the profile of the currently authenticated user.
-     *
-     * @return the current user's profile information
-     */
-    @GetMapping("/me")
-    @Operation(summary = "Get current user profile")
-    public UserResponseDto me() {
+  /**
+   * Retrieves the profile of the currently authenticated user.
+   *
+   * @return the current user's profile information
+   */
+  @GetMapping("/me")
+  @Operation(summary = "Get current user profile")
+  public UserResponseDto me() {
+    LOGGER.info("Fetching profile for authenticated user");
 
-        logger.info("Fetching profile for authenticated user");
+    User user = userService.getCurrentUser();
 
-        User user = userService.getCurrentUser();
+    UserResponseDto response =
+        new UserResponseDto(
+            user.getId(),
+            user.getUsername(),
+            user.getFirstName(),
+            user.getLastName(),
+            user.getEmail());
 
-        UserResponseDto response = new UserResponseDto(
-                user.getId(),
-                user.getUsername(),
-                user.getFirstName(),
-                user.getLastName(),
-                user.getEmail());
+    LOGGER.debug("Profile fetched successfully for user: {}", user.getUsername());
 
-        logger.debug(
-                "Profile fetched successfully for user: {}",
-                user.getUsername());
-
-        return response;
-    }
+    return response;
+  }
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/controller/UserController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/UserController.java
@@ -1,0 +1,52 @@
+package com.huseynovvusal.springblogapi.controller;
+
+import com.huseynovvusal.springblogapi.dto.response.UserResponseDto;
+import com.huseynovvusal.springblogapi.model.User;
+import com.huseynovvusal.springblogapi.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+public class UserController {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(UserController.class);
+
+    private final UserService userService;
+
+    /**
+     * Retrieves the profile of the currently authenticated user.
+     *
+     * @return the current user's profile information
+     */
+    @GetMapping("/me")
+    @Operation(summary = "Get current user profile")
+    public UserResponseDto me() {
+
+        logger.info("Fetching profile for authenticated user");
+
+        User user = userService.getCurrentUser();
+
+        UserResponseDto response = new UserResponseDto(
+                user.getId(),
+                user.getUsername(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getEmail());
+
+        logger.debug(
+                "Profile fetched successfully for user: {}",
+                user.getUsername());
+
+        return response;
+    }
+}


### PR DESCRIPTION
feat: add GET /users/me endpoint for authenticated user profile

Added UserController with /users/me endpoint
Used existing UserService.getCurrentUser() to retrieve the authenticated user Returned UserResponseDto to prevent exposing password information Added Swagger documentation with @Operation and @SecurityRequirement Added logging consistent with other controllers