### PR TITLE
fix : issue-85

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/dto/response/BlogResponseDto.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/response/BlogResponseDto.java
@@ -27,4 +27,7 @@ public class BlogResponseDto {
 
   /** Summary information about the author of the blog. */
   UserSummaryDto author;
+
+  /** Number of times the blog post has been viewed. */
+  Long views;
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/mapper/BlogMapper.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/mapper/BlogMapper.java
@@ -28,7 +28,8 @@ public final class BlogMapper {
         blog.getContent(),
         blog.getCreatedAt(),
         blog.getUpdatedAt(),
-        toUserSummary(blog.getAuthor()));
+        toUserSummary(blog.getAuthor()),
+        blog.getViews());
   }
 
   /**

--- a/src/main/java/com/huseynovvusal/springblogapi/repository/BlogRepository.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/repository/BlogRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Repository interface for accessing {@link Blog} entities. Supports pagination, dynamic filtering,
@@ -29,4 +32,12 @@ public interface BlogRepository extends JpaRepository<Blog, Long>, JpaSpecificat
    */
   @EntityGraph(attributePaths = {"author"})
   Blog findWithAuthorById(Long id);
+
+  /**
+   * Increments the view count of a blog post by 1. This method is annotated with @Modifying to
+   * indicate
+   */
+  @Modifying
+  @Query("update Blog b set b.views = b.views + 1 where b.id = :id")
+  void incrementViews(@Param("id") Long id);
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Service class for managing blog-related operations. Handles creation, retrieval, filtering, and
@@ -52,15 +53,24 @@ public class BlogService {
   }
 
   /**
-   * Retrieves a blog by its ID.
+   * Retrieves a blog by its ID and increments its view count.
+   *
+   * <p>CACHING DECISION: Caching is intentionally disabled (see commented @Cacheable annotation) to
+   * ensure view counts are always accurate. If caching were enabled, the result could be served
+   * from cache on subsequent calls, causing the increment logic to be skipped and returning a stale
+   * view count. Since view count accuracy is critical, we prioritize correctness over caching
+   * performance.
    *
    * @param id the blog ID
-   * @return the corresponding blog response DTO
+   * @return the corresponding blog response DTO with current view count
    * @throws NoSuchElementException if the blog is not found
    */
-  @Cacheable(value = "blog", key = "#id")
+
+  // @Cacheable(value = "blog", key = "#id")
+  @Transactional
   public BlogResponseDto getById(Long id) {
     log.debug("Fetching blog by ID: {}", id);
+    blogRepository.incrementViews(id);
     Blog blog =
         blogRepository
             .findById(id)

--- a/src/test/java/com/huseynovvusal/springblogapi/service/BlogServiceTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/service/BlogServiceTest.java
@@ -1,0 +1,87 @@
+package com.huseynovvusal.springblogapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.huseynovvusal.springblogapi.dto.response.BlogResponseDto;
+import com.huseynovvusal.springblogapi.model.Blog;
+import com.huseynovvusal.springblogapi.model.User;
+import com.huseynovvusal.springblogapi.repository.BlogRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BlogService Unit Tests")
+class BlogServiceTest {
+
+  @Mock private BlogRepository blogRepository;
+
+  private BlogService blogService;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+    blogService = new BlogService(blogRepository, null, null);
+  }
+
+  @Test
+  @DisplayName("should increment views when blog is fetched by ID")
+  void shouldIncrementViewsWhenGetById() {
+    // Given
+    Long blogId = 1L;
+    Blog blog = new Blog();
+    blog.setId(blogId);
+    blog.setTitle("Test Blog");
+    blog.setContent("Test Content");
+    blog.setViews(0L);
+
+    User author = new User();
+    author.setId(1L);
+    author.setUsername("testuser");
+    blog.setAuthor(author);
+
+    when(blogRepository.findById(blogId)).thenReturn(Optional.of(blog));
+
+    // When
+    BlogResponseDto result = blogService.getById(blogId);
+
+    // Then
+    verify(blogRepository).incrementViews(eq(blogId));
+    verify(blogRepository).findById(eq(blogId));
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(blogId);
+  }
+
+  @Test
+  @DisplayName("should increment views exactly once per getById call")
+  void shouldIncrementViewsExactlyOnce() {
+    // Given
+    Long blogId = 5L;
+    Blog blog = new Blog();
+    blog.setId(blogId);
+    blog.setTitle("Another Blog");
+    blog.setContent("Another Content");
+    blog.setViews(10L);
+
+    User author = new User();
+    author.setId(2L);
+    author.setUsername("anotheruser");
+    blog.setAuthor(author);
+
+    when(blogRepository.findById(blogId)).thenReturn(Optional.of(blog));
+
+    // When
+    blogService.getById(blogId);
+
+    // Then
+    verify(blogRepository).incrementViews(eq(blogId));
+  }
+}


### PR DESCRIPTION
## 📝 Description
Implements blog post view count tracking. Each time a blog is retrieved, its view count is automatically incremented by 1.

## 🎯 Issue
Fixes #85

## ✨ Changes
- Added `views` field to `BlogResponseDto` to expose view count
- Updated `BlogMapper.toDto()` to map views from blog entity
- Added `incrementViews()` repository method using `@Modifying` query
- Modified `BlogService.getById()` to increment views on every fetch
- Disabled caching (`@Cacheable`) to ensure view counts are always accurate

## 🔍 Why caching is disabled
Without this, cached results would skip the increment logic, returning stale view counts. Accuracy is prioritized over caching performance for this feature.

## 🧪 Testing
- [ ] Unit test for `incrementViews()` logic
- [ ] Integration test for `getById()` verifying view count increments
- [ ] Test that multiple fetches increment correctly
- [ ] Edge case: verify view count doesn't reset on updates

## ⚠️ Notes
- This is a transactional operation to ensure view count consistency
- View increments happen at fetch time, not at update time