### PR TITLE
fix: resolve issue-79

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/controller/UserController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.huseynovvusal.springblogapi.controller;
 
 import com.huseynovvusal.springblogapi.dto.response.UserResponseDto;
-import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -32,18 +31,6 @@ public class UserController {
   public UserResponseDto me() {
     LOGGER.info("Fetching profile for authenticated user");
 
-    User user = userService.getCurrentUser();
-
-    UserResponseDto response =
-        new UserResponseDto(
-            user.getId(),
-            user.getUsername(),
-            user.getFirstName(),
-            user.getLastName(),
-            user.getEmail());
-
-    LOGGER.debug("Profile fetched successfully for user: {}", user.getUsername());
-
-    return response;
+    return userService.getCurrentUserProfile();
   }
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/mapper/UserMapper.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/mapper/UserMapper.java
@@ -1,0 +1,46 @@
+package com.huseynovvusal.springblogapi.mapper;
+
+import com.huseynovvusal.springblogapi.dto.response.UserResponseDto;
+import com.huseynovvusal.springblogapi.model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for mapping {@link User} entities to {@link UserResponseDto} DTOs. Centralizes user
+ * DTO conversion logic and provides consistent logging.
+ */
+public final class UserMapper {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserMapper.class);
+
+  // Prevent instantiation
+  private UserMapper() {}
+
+  /**
+   * Converts a {@link User} entity to a {@link UserResponseDto}.
+   *
+   * @param user the user entity to convert
+   * @return the corresponding UserResponseDto, or null if user is null
+   */
+  public static UserResponseDto toResponseDto(User user) {
+    if (user == null) {
+      LOGGER.debug("[UserMapper] User is null, returning null");
+      return null;
+    }
+
+    LOGGER.debug(
+        "[UserMapper] Converting User to UserResponseDto for user: {}", user.getUsername());
+
+    UserResponseDto response =
+        new UserResponseDto(
+            user.getId(),
+            user.getUsername(),
+            user.getFirstName(),
+            user.getLastName(),
+            user.getEmail());
+
+    LOGGER.debug("[UserMapper] User conversion completed for user: {}", user.getUsername());
+
+    return response;
+  }
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/service/UserService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/UserService.java
@@ -2,6 +2,8 @@ package com.huseynovvusal.springblogapi.service;
 
 import com.huseynovvusal.springblogapi.dto.BlockUserRequest;
 import com.huseynovvusal.springblogapi.dto.BlockUserResponse;
+import com.huseynovvusal.springblogapi.dto.response.UserResponseDto;
+import com.huseynovvusal.springblogapi.mapper.UserMapper;
 import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.UserRepository;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
@@ -36,6 +38,22 @@ public class UserService {
     String username = authentication.getName();
     log.info("[UserService] Current username: {}", username);
     return getUserByUsername(username);
+  }
+
+  /**
+   * Retrieves the currently authenticated user's profile as a DTO. This method handles both
+   * authentication check and DTO conversion, keeping business logic and data transformation in the
+   * service layer.
+   *
+   * @return the current user's profile information as UserResponseDto
+   * @throws UsernameNotFoundException if the user is not authenticated
+   */
+  public UserResponseDto getCurrentUserProfile() {
+    log.info("[UserService] Retrieving current user profile");
+    User user = getCurrentUser();
+    UserResponseDto response = UserMapper.toResponseDto(user);
+    log.debug("[UserService] User profile retrieved for user: {}", user.getUsername());
+    return response;
   }
 
   /**

--- a/src/test/java/com/huseynovvusal/springblogapi/controller/UserControllerTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/controller/UserControllerTest.java
@@ -1,0 +1,107 @@
+package com.huseynovvusal.springblogapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.huseynovvusal.springblogapi.dto.response.UserResponseDto;
+import com.huseynovvusal.springblogapi.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserController Tests")
+class UserControllerTest {
+
+  @Mock private UserService userService;
+
+  @InjectMocks private UserController userController;
+
+  private UserResponseDto testUserResponseDto;
+
+  @BeforeEach
+  void setUp() {
+    testUserResponseDto = new UserResponseDto(1L, "testuser", "Test", "User", "test@example.com");
+  }
+
+  @Test
+  @DisplayName("Should return current user profile successfully")
+  void testMeSuccess() {
+    // Arrange
+    when(userService.getCurrentUserProfile()).thenReturn(testUserResponseDto);
+
+    // Act
+    UserResponseDto result = userController.me();
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(testUserResponseDto.getId(), result.getId());
+    assertEquals("testuser", result.getUsername());
+    assertEquals("Test", result.getFirstName());
+    assertEquals("User", result.getLastName());
+    assertEquals("test@example.com", result.getEmail());
+
+    verify(userService, times(1)).getCurrentUserProfile();
+  }
+
+  @Test
+  @DisplayName("Should throw UsernameNotFoundException when user not authenticated")
+  void testMeThrowsExceptionWhenNotAuthenticated() {
+    // Arrange
+    when(userService.getCurrentUserProfile())
+        .thenThrow(new UsernameNotFoundException("No authenticated user found"));
+
+    // Act & Assert
+    assertThrows(UsernameNotFoundException.class, () -> userController.me());
+    verify(userService, times(1)).getCurrentUserProfile();
+  }
+
+  @Test
+  @DisplayName("Should return user profile with correct fields")
+  void testMeResponseContainsCorrectFields() {
+    // Arrange
+    UserResponseDto expected =
+        new UserResponseDto(5L, "john_doe", "John", "Doe", "john@example.com");
+    when(userService.getCurrentUserProfile()).thenReturn(expected);
+
+    // Act
+    UserResponseDto result = userController.me();
+
+    // Assert
+    assertEquals(5L, result.getId());
+    assertEquals("john_doe", result.getUsername());
+    assertEquals("John", result.getFirstName());
+    assertEquals("Doe", result.getLastName());
+    assertEquals("john@example.com", result.getEmail());
+  }
+
+  @Test
+  @DisplayName("Should not expose password in response")
+  void testMeDoesNotIncludePassword() {
+    // Arrange
+    when(userService.getCurrentUserProfile()).thenReturn(testUserResponseDto);
+
+    // Act
+    UserResponseDto result = userController.me();
+
+    // Assert - UserResponseDto should not have password field
+    assertNotNull(result);
+    assertTrue(
+        result.getClass().getDeclaredFields().length
+            == 5); // Only 5 fields: id, username, firstName, lastName, email
+    assertFalse(
+        java.util.Arrays.stream(result.getClass().getDeclaredFields())
+            .anyMatch(f -> f.getName().equals("password")));
+  }
+}

--- a/src/test/java/com/huseynovvusal/springblogapi/mapper/UserMapperTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/mapper/UserMapperTest.java
@@ -1,0 +1,102 @@
+package com.huseynovvusal.springblogapi.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.huseynovvusal.springblogapi.dto.response.UserResponseDto;
+import com.huseynovvusal.springblogapi.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("UserMapper Tests")
+class UserMapperTest {
+
+  private User testUser;
+
+  @BeforeEach
+  void setUp() {
+    testUser = new User();
+    testUser.setId(1L);
+    testUser.setUsername("john_doe");
+    testUser.setFirstName("John");
+    testUser.setLastName("Doe");
+    testUser.setEmail("john@example.com");
+    testUser.setPassword("hashedPassword");
+    testUser.setBlocked(false);
+  }
+
+  @Test
+  @DisplayName("Should convert User to UserResponseDto successfully")
+  void testToResponseDtoSuccess() {
+    // Act
+    UserResponseDto result = UserMapper.toResponseDto(testUser);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(1L, result.getId());
+    assertEquals("john_doe", result.getUsername());
+    assertEquals("John", result.getFirstName());
+    assertEquals("Doe", result.getLastName());
+    assertEquals("john@example.com", result.getEmail());
+  }
+
+  @Test
+  @DisplayName("Should not include password in converted DTO")
+  void testToResponseDtoExcludesPassword() {
+    // Act
+    UserResponseDto result = UserMapper.toResponseDto(testUser);
+
+    // Assert
+    assertNotNull(result);
+    assertFalse(
+        java.util.Arrays.stream(result.getClass().getDeclaredFields())
+            .anyMatch(f -> f.getName().equals("password")));
+  }
+
+  @Test
+  @DisplayName("Should return null when User is null")
+  void testToResponseDtoWithNullUser() {
+    // Act
+    UserResponseDto result = UserMapper.toResponseDto(null);
+
+    // Assert
+    assertNull(result);
+  }
+
+  @Test
+  @DisplayName("Should map all required fields correctly")
+  void testToResponseDtoMapsAllFields() {
+    // Arrange
+    testUser.setId(99L);
+    testUser.setUsername("test_username");
+    testUser.setFirstName("FirstName");
+    testUser.setLastName("LastName");
+    testUser.setEmail("test@mail.com");
+
+    // Act
+    UserResponseDto result = UserMapper.toResponseDto(testUser);
+
+    // Assert
+    assertEquals(99L, result.getId());
+    assertEquals("test_username", result.getUsername());
+    assertEquals("FirstName", result.getFirstName());
+    assertEquals("LastName", result.getLastName());
+    assertEquals("test@mail.com", result.getEmail());
+  }
+
+  @Test
+  @DisplayName("Should handle user with special characters in email")
+  void testToResponseDtoWithSpecialCharactersInEmail() {
+    // Arrange
+    testUser.setEmail("user+test@example.co.uk");
+
+    // Act
+    UserResponseDto result = UserMapper.toResponseDto(testUser);
+
+    // Assert
+    assertEquals("user+test@example.co.uk", result.getEmail());
+  }
+}

--- a/src/test/java/com/huseynovvusal/springblogapi/service/UserServiceTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/service/UserServiceTest.java
@@ -1,24 +1,35 @@
 package com.huseynovvusal.springblogapi.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.huseynovvusal.springblogapi.dto.BlockUserRequest;
 import com.huseynovvusal.springblogapi.dto.BlockUserResponse;
+import com.huseynovvusal.springblogapi.dto.response.UserResponseDto;
 import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 @ExtendWith(MockitoExtension.class)
@@ -85,5 +96,73 @@ class UserServiceTest {
     // When & Then
     BlockUserRequest request = new BlockUserRequest(username, true);
     assertThrows(UsernameNotFoundException.class, () -> userService.changeBlockStatus(request));
+  }
+
+  // Additional test for getcurrentUserProfile
+
+  @Test
+  @DisplayName("Should retrieve current user profile successfully")
+  void testGetCurrentUserProfileSuccess() {
+    // Arrange
+    User testUser = new User();
+    testUser.setId(1L);
+    testUser.setUsername("testuser");
+    testUser.setFirstName("Test");
+    testUser.setLastName("User");
+    testUser.setEmail("test@example.com");
+
+    when(userRepository.findByUsername("testuser")).thenReturn(testUser);
+    mockSecurityContext("testuser");
+
+    // Act
+    UserResponseDto result = userService.getCurrentUserProfile();
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(1L, result.getId());
+    assertEquals("testuser", result.getUsername());
+    assertEquals("Test", result.getFirstName());
+    assertEquals("User", result.getLastName());
+    assertEquals("test@example.com", result.getEmail());
+
+    verify(userRepository, times(1)).findByUsername("testuser");
+  }
+
+  @Test
+  @DisplayName("Should throw UsernameNotFoundException when user not found")
+  void testGetCurrentUserProfileUserNotFound() {
+    // Arrange
+    when(userRepository.findByUsername("nonexistent")).thenReturn(null);
+    mockSecurityContext("nonexistent");
+
+    // Act & Assert
+    assertThrows(UsernameNotFoundException.class, () -> userService.getCurrentUserProfile());
+    verify(userRepository, times(1)).findByUsername("nonexistent");
+  }
+
+  @Test
+  @DisplayName("Should throw UsernameNotFoundException when not authenticated")
+  void testGetCurrentUserProfileNotAuthenticated() {
+    // Arrange
+    mockSecurityContextNull();
+
+    // Act & Assert
+    assertThrows(UsernameNotFoundException.class, () -> userService.getCurrentUserProfile());
+    verify(userRepository, never()).findByUsername(anyString());
+  }
+
+  private void mockSecurityContext(String username) {
+    SecurityContext securityContext = mock(SecurityContext.class);
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    when(authentication.getName()).thenReturn(username);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext); // Direct call, not mockStatic
+  }
+
+  private void mockSecurityContextNull() {
+    SecurityContext securityContext = mock(SecurityContext.class);
+    when(securityContext.getAuthentication()).thenReturn(null);
+    SecurityContextHolder.setContext(securityContext);
   }
 }


### PR DESCRIPTION
## 🚀 Refactor User Profile Handling & Add Comprehensive Tests

### 🔧 Changes Made

* Refactored `UserController.me()` to delegate profile retrieval to the service layer instead of constructing the response manually.
* Introduced a new `getCurrentUserProfile()` method in `UserService` to encapsulate authentication handling and DTO conversion.
* Added a new `UserMapper` utility class to centralize mapping logic from `User` entity to `UserResponseDto`.
* Improved logging across service and mapper layers for better traceability.

### 🧪 Tests Added

* Added unit tests for:

  * `UserController` (profile retrieval, exception handling, response validation)
  * `UserMapper` (mapping correctness, null handling, field validation)
  * `UserService#getCurrentUserProfile` (success, user not found, unauthenticated scenarios)

### 🎯 Benefits

* Improves separation of concerns by moving business logic out of the controller.
* Enhances maintainability by centralizing DTO mapping logic.
* Increases test coverage and ensures reliability of user profile functionality.
* Aligns with clean architecture and best practices.

### ⚠️ Notes

* Ensures sensitive fields like `password` are not exposed in API responses.
* All tests and formatting checks have been validated locally using:

  * `./gradlew check`

---

### ✅ Checklist

* [x] Code formatted with Spotless
* [x] Checkstyle issues resolved
* [x] All tests passing
* [x] New tests added
* [x] No breaking changes


