### PR TITLE
Cap password length to BCrypt's 72-byte limit

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/dto/RegisterRequest.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/RegisterRequest.java
@@ -38,9 +38,6 @@ public class RegisterRequest {
 
   /** Password chosen by the user. */
   @NotBlank(message = "Password is required")
-  @Size(
-      min = 8,
-      max = 72,
-      message = "Password must be between 8 and 72 characters long")
+  @Size(min = 8, max = 72, message = "Password must be between 8 and 72 characters long")
   private String password;
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/RegisterRequest.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/RegisterRequest.java
@@ -38,6 +38,9 @@ public class RegisterRequest {
 
   /** Password chosen by the user. */
   @NotBlank(message = "Password is required")
-  @Size(min = 8, message = "Password must be at least 8 characters long")
+  @Size(
+      min = 8,
+      max = 72,
+      message = "Password must be between 8 and 72 characters long")
   private String password;
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/ResetPasswordRequest.java
@@ -24,9 +24,6 @@ public class ResetPasswordRequest {
    * requirements.
    */
   @NotBlank(message = "New password cannot be blank")
-  @Size(
-      min = 8,
-      max = 72,
-      message = "Password must be between 8 and 72 characters long")
+  @Size(min = 8, max = 72, message = "Password must be between 8 and 72 characters long")
   private String newPassword;
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/ResetPasswordRequest.java
@@ -24,6 +24,9 @@ public class ResetPasswordRequest {
    * requirements.
    */
   @NotBlank(message = "New password cannot be blank")
-  @Size(min = 8, message = "Password must be at least 8 characters long")
+  @Size(
+      min = 8,
+      max = 72,
+      message = "Password must be between 8 and 72 characters long")
   private String newPassword;
 }

--- a/src/test/java/com/huseynovvusal/springblogapi/integration/AuthenticationIntegrationTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/integration/AuthenticationIntegrationTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.huseynovvusal.springblogapi.dto.LoginRequest;
 import com.huseynovvusal.springblogapi.dto.RefreshTokenRequest;
 import com.huseynovvusal.springblogapi.dto.RegisterRequest;
+import com.huseynovvusal.springblogapi.dto.ResetPasswordRequest;
 import com.huseynovvusal.springblogapi.repository.RefreshTokenRepository;
 import com.huseynovvusal.springblogapi.repository.UserRepository;
 import com.huseynovvusal.springblogapi.service.EmailService;
@@ -40,6 +41,7 @@ class AuthenticationIntegrationTest {
   private static final String REGISTER_PATH = CONTEXT_PATH + "/auth/register";
   private static final String LOGIN_PATH = CONTEXT_PATH + "/auth/login";
   private static final String REFRESH_PATH = CONTEXT_PATH + "/auth/refresh";
+  private static final String RESET_PASSWORD_PATH = CONTEXT_PATH + "/auth/reset-password";
 
   @Autowired private MockMvc mockMvc;
 
@@ -159,6 +161,45 @@ class AuthenticationIntegrationTest {
                         new RefreshTokenRequest("invalid-refresh-token"))))
         .andExpect(status().isInternalServerError())
         .andExpect(jsonPath("$.message").value("Unexpected error"));
+  }
+
+  @Test
+  @DisplayName("Should reject registration when password exceeds max length")
+  void registerShouldRejectLongPassword() throws Exception {
+    String longPassword = "P".repeat(73);
+    RegisterRequest request =
+        new RegisterRequest("Alice", "Tester", "alice", "alice@example.com", longPassword);
+
+    mockMvc
+        .perform(
+            post(REGISTER_PATH)
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("Validation failed"))
+        .andExpect(
+            jsonPath("$.fieldErrors.password")
+                .value("Password must be between 8 and 72 characters long"));
+  }
+
+  @Test
+  @DisplayName("Should reject password reset when password exceeds max length")
+  void resetPasswordShouldRejectLongPassword() throws Exception {
+    String longPassword = "P".repeat(73);
+    ResetPasswordRequest request = new ResetPasswordRequest("valid-token", longPassword);
+
+    mockMvc
+        .perform(
+            post(RESET_PASSWORD_PATH)
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("Validation failed"))
+        .andExpect(
+            jsonPath("$.fieldErrors.newPassword")
+                .value("Password must be between 8 and 72 characters long"));
   }
 
   private JsonNode register(RegisterRequest request) throws Exception {


### PR DESCRIPTION
## What

Adds a maximum password length validation for registration and password reset requests.

## Why

BCrypt only considers the first 72 bytes of a password. Without validation, overly long passwords can result in unexpected behavior and poor user experience.

## Changes

* Added `max = 72` validation to `RegisterRequest.password`.
* Added `max = 72` validation to `ResetPasswordRequest.newPassword`.
* Added integration tests covering passwords longer than 72 characters.
* Verified validation errors return HTTP 400 through the existing exception handling flow.

## Verification

* Registration with a password longer than 72 characters returns HTTP 400.
* Password reset with a password longer than 72 characters returns HTTP 400.
* Existing tests continue to pass.

Fixes #81
