### PR TITLE
issue-resolve 09

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/controller/LikeController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/LikeController.java
@@ -1,0 +1,106 @@
+package com.huseynovvusal.springblogapi.controller;
+
+import com.huseynovvusal.springblogapi.dto.response.LikeResponseDto;
+import com.huseynovvusal.springblogapi.exception.BlogNotFoundException;
+import com.huseynovvusal.springblogapi.service.LikeService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for managing blog likes. Supports adding, removing, toggling, checking, and listing
+ * likes. All endpoints require a valid JWT token — enforced by SecurityConfig's
+ * anyRequest().authenticated().
+ */
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/likes")
+@RequiredArgsConstructor
+public class LikeController {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(LikeController.class);
+
+  private final LikeService likeService;
+
+  /**
+   * Likes the specified blog for the current user. Idempotent — calling multiple times has no extra
+   * effect.
+   *
+   * @param blogId the ID of the blog to like
+   * @throws BlogNotFoundException if the blog does not exist
+   */
+  @PostMapping("/{blogId}")
+  public void add(@PathVariable Long blogId) throws BlogNotFoundException {
+    LOGGER.info("Adding like for blog ID: {}", blogId);
+    likeService.addLike(blogId);
+  }
+
+  /**
+   * Unlikes the specified blog for the current user. No-op if the user has not liked the post.
+   *
+   * @param blogId the ID of the blog to unlike
+   */
+  @DeleteMapping("/{blogId}")
+  public void remove(@PathVariable Long blogId) {
+    LOGGER.info("Removing like for blog ID: {}", blogId);
+    likeService.removeLike(blogId);
+  }
+
+  /**
+   * Toggles like status for the current user on the specified blog. Returns true if now liked,
+   * false if unliked.
+   *
+   * @param blogId the ID of the blog to toggle
+   * @return true if liked, false if unliked
+   * @throws BlogNotFoundException if the blog does not exist
+   */
+  @PostMapping("/{blogId}/toggle")
+  public boolean toggle(@PathVariable Long blogId) throws BlogNotFoundException {
+    LOGGER.info("Toggling like for blog ID: {}", blogId);
+    boolean result = likeService.toggle(blogId);
+    LOGGER.debug("Toggle result for blog ID {}: {}", blogId, result);
+    return result;
+  }
+
+  /**
+   * Checks if the current user has already liked the specified blog. Used by frontend to render
+   * like button state correctly.
+   *
+   * @param blogId the ID of the blog to check
+   * @return true if liked by current user, false otherwise
+   */
+  @GetMapping("/check")
+  public boolean isLiked(@RequestParam Long blogId) {
+    LOGGER.info("Checking like status for blog ID: {}", blogId);
+    boolean result = likeService.isLiked(blogId);
+    LOGGER.debug("Like status for blog ID {}: {}", blogId, result);
+    return result;
+  }
+
+  /**
+   * Returns the like count and paginated list of users who liked the specified blog. likedUsers
+   * list is paginated — prevents unbounded response on popular posts.
+   *
+   * @param blogId the ID of the blog
+   * @param page page number (default 0)
+   * @param size page size (default 20)
+   * @return LikeResponseDto with likeCount and likedUsers
+   */
+  @GetMapping("/{blogId}")
+  public LikeResponseDto getLikes(
+      @PathVariable Long blogId,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size) {
+    LOGGER.info("Getting likes for blog ID: {}", blogId);
+    return likeService.getLikes(blogId, PageRequest.of(page, size));
+  }
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/controller/UserController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/UserController.java
@@ -30,7 +30,6 @@ public class UserController {
   @Operation(summary = "Get current user profile")
   public UserResponseDto me() {
     LOGGER.info("Fetching profile for authenticated user");
-
     return userService.getCurrentUserProfile();
   }
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/response/BlogResponseDto.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/response/BlogResponseDto.java
@@ -30,4 +30,7 @@ public class BlogResponseDto {
 
   /** Number of times the blog post has been viewed. */
   Long views;
+
+  /** Total number of likes the blog post has received. */
+  Long likeCount;
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/dto/response/LikeResponseDto.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/dto/response/LikeResponseDto.java
@@ -1,0 +1,27 @@
+package com.huseynovvusal.springblogapi.dto.response;
+
+import jakarta.annotation.Nullable;
+import java.util.List;
+import lombok.Value;
+
+/**
+ * Data Transfer Object representing the like status of a blog post. Always includes the total like
+ * count. Optionally includes the list of users who liked the post — only populated when explicitly
+ * requested to avoid unnecessary DB queries on every call.
+ */
+@Value
+public class LikeResponseDto {
+
+  /**
+   * Total number of likes for the blog post. Derived from COUNT query on the likes table — no full
+   * row loading needed.
+   */
+  long likeCount;
+
+  /**
+   * Optional list of users who liked the blog post. Null when not requested (e.g. standard blog
+   * listing). Populated only on explicit "get likers" endpoint call. Uses UserSummaryDto to keep
+   * payload minimal — only id, username, firstName, lastName.
+   */
+  @Nullable List<UserSummaryDto> likedUsers;
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/mapper/BlogMapper.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/mapper/BlogMapper.java
@@ -14,10 +14,11 @@ public final class BlogMapper {
   /**
    * Converts a {@link Blog} entity to a {@link BlogResponseDto}.
    *
-   * @param blog the blog entity to convert
+   * @param blog the blog entity to convert * @param likeCount the precomputed like count from
+   *     LikeRepository
    * @return the corresponding BlogResponseDto
    */
-  public static BlogResponseDto toDto(Blog blog) {
+  public static BlogResponseDto toDto(Blog blog, Long likeCount) {
     if (blog == null) {
       return null;
     }
@@ -29,7 +30,8 @@ public final class BlogMapper {
         blog.getCreatedAt(),
         blog.getUpdatedAt(),
         toUserSummary(blog.getAuthor()),
-        blog.getViews());
+        blog.getViews(),
+        likeCount); // use toDto(blog, likeCount) when count is needed
   }
 
   /**

--- a/src/main/java/com/huseynovvusal/springblogapi/model/Likes.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/model/Likes.java
@@ -1,0 +1,74 @@
+package com.huseynovvusal.springblogapi.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+/**
+ * Entity representing a user's like on a blog post. Ensures each user can like a blog only once via
+ * unique constraint.
+ */
+@Entity
+@Table(
+    name = "likes", // 'like' is a reserved SQL keyword, so plural form is used
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uk_user_blog_like", // named constraint for easier debugging in DB logs
+            columnNames = {"user_id", "blog_id"}))
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Likes {
+
+  /** Unique identifier for the like entry. */
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  /**
+   * The user who liked the post. LAZY fetch avoids loading the full User object unless explicitly
+   * needed.
+   */
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(
+      name = "user_id",
+      nullable = false,
+      foreignKey = @ForeignKey(name = "fk_like_user")) // named FK for schema clarity
+  private User user;
+
+  /**
+   * The blog post that was liked. LAZY fetch avoids loading the full Blog object unless explicitly
+   * needed.
+   */
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(
+      name = "blog_id",
+      nullable = false,
+      foreignKey = @ForeignKey(name = "fk_like_blog")) // named FK for schema clarity
+  private Blog blog;
+
+  /**
+   * Timestamp when the like was created. Automatically set by Hibernate on insert, never updated.
+   * Useful for time-based queries like "most liked this week".
+   */
+  @CreationTimestamp
+  @Column(nullable = false, updatable = false)
+  private Instant createdAt;
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/repository/LikeRepository.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/repository/LikeRepository.java
@@ -1,0 +1,40 @@
+package com.huseynovvusal.springblogapi.repository;
+
+import com.huseynovvusal.springblogapi.model.Likes;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository interface for managing {@link Like} entities. Provides methods for checking existence,
+ * counting, deletion, and retrieval. Spring Data JPA derives all queries from method names — no
+ * manual SQL needed.
+ */
+public interface LikeRepository extends JpaRepository<Likes, Long> {
+
+  /**
+   * Checks if a like exists for the given user and blog. Used in service layer to prevent duplicate
+   * likes (happy path check). Spring Data translates this to: SELECT COUNT(*) > 0 WHERE user_id=?
+   * AND blog_id=?
+   */
+  boolean existsByUser_IdAndBlog_Id(Long userId, Long blogId);
+
+  /**
+   * Deletes a like by user ID and blog ID. Used for unlike operation — removes the row directly
+   * without loading the entity. Returns number of rows deleted (0 if not found, 1 if deleted).
+   */
+  long deleteByUser_IdAndBlog_Id(Long userId, Long blogId);
+
+  /**
+   * Counts total likes for a given blog. Used to return like count in blog responses. Spring Data
+   * translates this to: SELECT COUNT(*) WHERE blog_id=?
+   */
+  long countByBlog_Id(Long blogId);
+
+  /**
+   * Retrieves all likes for a given blog with pagination. Used for the optional "list of users who
+   * liked this post" feature. Spring Data translates this to: SELECT * WHERE blog_id=? LIMIT ?
+   * OFFSET ?
+   */
+  Page<Likes> findAllByBlog_Id(Long blogId, Pageable pageable);
+}

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BlogService.java
@@ -13,6 +13,7 @@ import com.huseynovvusal.springblogapi.mapper.BlogMapper;
 import com.huseynovvusal.springblogapi.model.Blog;
 import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.BlogRepository;
+import com.huseynovvusal.springblogapi.repository.LikeRepository;
 import com.huseynovvusal.springblogapi.security.RichTextSanitizer;
 import java.time.Instant;
 import java.util.List;
@@ -39,6 +40,7 @@ public class BlogService {
   private final BlogRepository blogRepository;
   private final UserService userService;
   private final RichTextSanitizer richTextSanitizer;
+  private final LikeRepository likeRepository;
 
   /**
    * Retrieves all blogs with pagination.
@@ -49,7 +51,9 @@ public class BlogService {
   @Cacheable(value = "blogs", key = "#pageable")
   public Page<BlogResponseDto> getAllBlogs(Pageable pageable) {
     log.debug("Fetching all blogs with pagination: {}", pageable);
-    return blogRepository.findAll(pageable).map(BlogMapper::toDto);
+    return blogRepository
+        .findAll(pageable)
+        .map(blog -> BlogMapper.toDto(blog, likeRepository.countByBlog_Id(blog.getId())));
   }
 
   /**
@@ -79,7 +83,7 @@ public class BlogService {
                   log.warn("Blog not found with ID: {}", id);
                   return new NoSuchElementException("Blog not found");
                 });
-    return BlogMapper.toDto(blog);
+    return BlogMapper.toDto(blog, likeRepository.countByBlog_Id(blog.getId()));
   }
 
   /**
@@ -93,7 +97,9 @@ public class BlogService {
   public Page<BlogResponseDto> getByAuthor(String username, Pageable pageable) {
     log.debug("Fetching blogs by author: {}", username);
     User author = userService.getUserByUsername(username);
-    return blogRepository.findByAuthor(author, pageable).map(BlogMapper::toDto);
+    return blogRepository
+        .findByAuthor(author, pageable)
+        .map(blog -> BlogMapper.toDto(blog, likeRepository.countByBlog_Id(blog.getId())));
   }
 
   /**
@@ -122,7 +128,7 @@ public class BlogService {
     Blog saved = blogRepository.save(blog);
     log.debug("Blog created with ID: {}", saved.getId());
 
-    return BlogMapper.toDto(saved);
+    return BlogMapper.toDto(blog, likeRepository.countByBlog_Id(blog.getId()));
   }
 
   /**
@@ -163,7 +169,9 @@ public class BlogService {
             titleContains(q),
             hasAnyTag(tags));
 
-    return blogRepository.findAll(spec, pageable).map(BlogMapper::toDto);
+    return blogRepository
+        .findAll(spec, pageable)
+        .map(blog -> BlogMapper.toDto(blog, likeRepository.countByBlog_Id(blog.getId())));
   }
 
   /**
@@ -178,6 +186,8 @@ public class BlogService {
   public Page<BlogResponseDto> search(String q, Pageable pageable) {
     log.debug("Searching blogs with keyword: {}", q);
     Specification<Blog> spec = Specification.where(textSearch(q)).or(tagContains(q));
-    return blogRepository.findAll(spec, pageable).map(BlogMapper::toDto);
+    return blogRepository
+        .findAll(spec, pageable)
+        .map(blog -> BlogMapper.toDto(blog, likeRepository.countByBlog_Id(blog.getId())));
   }
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/service/BookmarkService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/BookmarkService.java
@@ -8,6 +8,7 @@ import com.huseynovvusal.springblogapi.model.Bookmark;
 import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.BlogRepository;
 import com.huseynovvusal.springblogapi.repository.BookmarkRepository;
+import com.huseynovvusal.springblogapi.repository.LikeRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class BookmarkService implements SecurityAwareService {
   private final BookmarkRepository bookmarkRepository;
   private final BlogRepository blogRepository;
   private final EntityManager entityManager;
+  private final LikeRepository likeRepository;
 
   /**
    * Adds a bookmark for the current user to the specified blog. Idempotent: does nothing if already
@@ -130,6 +132,6 @@ public class BookmarkService implements SecurityAwareService {
     return bookmarkRepository
         .findAllByUser_Id(userId, pageable)
         .map(Bookmark::getBlog)
-        .map(BlogMapper::toDto);
+        .map(b -> BlogMapper.toDto(b, likeRepository.countByBlog_Id(b.getId())));
   }
 }

--- a/src/main/java/com/huseynovvusal/springblogapi/service/LikeService.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/service/LikeService.java
@@ -1,0 +1,166 @@
+package com.huseynovvusal.springblogapi.service;
+
+import com.huseynovvusal.springblogapi.dto.response.LikeResponseDto;
+import com.huseynovvusal.springblogapi.dto.response.UserSummaryDto;
+import com.huseynovvusal.springblogapi.exception.BlogNotFoundException;
+import com.huseynovvusal.springblogapi.model.Blog;
+import com.huseynovvusal.springblogapi.model.Likes;
+import com.huseynovvusal.springblogapi.model.User;
+import com.huseynovvusal.springblogapi.repository.BlogRepository;
+import com.huseynovvusal.springblogapi.repository.LikeRepository;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Service class for managing blog likes by authenticated users. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikeService implements SecurityAwareService {
+
+  private final LikeRepository likeRepository;
+  private final BlogRepository blogRepository;
+
+  /**
+   * EntityManager used to get a proxy reference to User by ID. Avoids an extra SELECT — only the FK
+   * value is needed when inserting a Like row.
+   */
+  private final EntityManager entityManager;
+
+  /**
+   * Adds a like for the current user on the specified blog. Idempotent — does nothing if the user
+   * already liked the post. Double-guarded: service-level existsBy check + DB unique constraint
+   * catch for race conditions.
+   *
+   * @param blogId the ID of the blog to like
+   * @throws BlogNotFoundException if the blog does not exist
+   */
+  @Transactional
+  public void addLike(Long blogId) throws BlogNotFoundException {
+    Long userId = currentUserId();
+
+    // Happy path guard — avoids hitting DB constraint on normal duplicate attempts
+    if (likeRepository.existsByUser_IdAndBlog_Id(userId, blogId)) {
+      log.debug("Like already exists for user {} and blog {}", userId, blogId);
+      return;
+    }
+
+    // Verify blog exists before inserting
+    Blog blog =
+        blogRepository
+            .findById(blogId)
+            .orElseThrow(
+                () -> new BlogNotFoundException(String.format("Blog not found: %d", blogId)));
+
+    try {
+      // getReference avoids SELECT on users table — only FK value needed for insert
+      User userRef = entityManager.getReference(User.class, userId);
+      likeRepository.save(Likes.builder().user(userRef).blog(blog).build());
+      log.info("Like added for user {} on blog {}", userId, blogId);
+    } catch (DataIntegrityViolationException e) {
+      // Two requests from the same user arrived simultaneously, both passed existsBy check
+      // DB unique constraint uk_user_blog_like caught the second insert — safe to ignore
+      log.warn("Race condition detected while adding like for user {} on blog {}", userId, blogId);
+    }
+  }
+
+  /**
+   * Removes a like for the current user from the specified blog. No-op if the user has not liked
+   * the post.
+   *
+   * @param blogId the ID of the blog to unlike
+   */
+  @Transactional
+  public void removeLike(Long blogId) {
+    Long userId = currentUserId();
+    likeRepository.deleteByUser_IdAndBlog_Id(userId, blogId);
+    log.info("Like removed for user {} on blog {}", userId, blogId);
+  }
+
+  /**
+   * Toggles the like status for the current user on the specified blog. If already liked — removes
+   * the like and returns false. If not liked — adds the like and returns true.
+   *
+   * @param blogId the ID of the blog to toggle like on
+   * @return true if now liked, false if unliked
+   * @throws BlogNotFoundException if the blog does not exist
+   */
+  @Transactional
+  public boolean toggle(Long blogId) throws BlogNotFoundException {
+    Long userId = currentUserId();
+
+    if (likeRepository.existsByUser_IdAndBlog_Id(userId, blogId)) {
+      // Already liked — remove it
+      likeRepository.deleteByUser_IdAndBlog_Id(userId, blogId);
+      log.info("Like toggled OFF for user {} on blog {}", userId, blogId);
+      return false;
+    } else {
+      // Not liked yet — add it
+      Blog blog =
+          blogRepository
+              .findById(blogId)
+              .orElseThrow(
+                  () -> new BlogNotFoundException(String.format("Blog not found: %d", blogId)));
+      User userRef = entityManager.getReference(User.class, userId);
+      likeRepository.save(Likes.builder().user(userRef).blog(blog).build());
+      log.info("Like toggled ON for user {} on blog {}", userId, blogId);
+      return true;
+    }
+  }
+
+  /**
+   * Checks if the current user has liked the specified blog. readOnly = true — Hibernate skips
+   * dirty checking, minor performance gain.
+   *
+   * @param blogId the ID of the blog to check
+   * @return true if liked by current user, false otherwise
+   */
+  @Transactional(readOnly = true)
+  public boolean isLiked(Long blogId) {
+    Long userId = currentUserId();
+    return likeRepository.existsByUser_IdAndBlog_Id(userId, blogId);
+  }
+
+  /**
+   * Returns the total like count for the specified blog. readOnly = true — only a COUNT query, no
+   * entity loading needed.
+   *
+   * @param blogId the ID of the blog
+   * @return total number of likes
+   */
+  @Transactional(readOnly = true)
+  public long getLikeCount(Long blogId) {
+    return likeRepository.countByBlog_Id(blogId);
+  }
+
+  /**
+   * Returns like count and the paginated list of users who liked the specified blog. likedUsers is
+   * populated here — only called on explicit request, not on every blog fetch. Each Like row's user
+   * is mapped to UserSummaryDto to keep the payload minimal.
+   *
+   * @param blogId the ID of the blog
+   * @param pageable pagination info for the likedUsers list
+   * @return LikeResponseDto with likeCount and likedUsers list
+   */
+  @Transactional(readOnly = true)
+  public LikeResponseDto getLikes(Long blogId, Pageable pageable) {
+    long likeCount = likeRepository.countByBlog_Id(blogId);
+
+    // Map each Like row's user to UserSummaryDto — minimal payload, no email exposed
+    Page<UserSummaryDto> likedUsers =
+        likeRepository
+            .findAllByBlog_Id(blogId, pageable)
+            .map(Likes::getUser)
+            .map(
+                u ->
+                    new UserSummaryDto(
+                        u.getId(), u.getUsername(), u.getFirstName(), u.getLastName()));
+
+    return new LikeResponseDto(likeCount, likedUsers.getContent());
+  }
+}

--- a/src/test/java/com/huseynovvusal/springblogapi/service/BlogServiceTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/service/BlogServiceTest.java
@@ -9,6 +9,7 @@ import com.huseynovvusal.springblogapi.dto.response.BlogResponseDto;
 import com.huseynovvusal.springblogapi.model.Blog;
 import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.BlogRepository;
+import com.huseynovvusal.springblogapi.repository.LikeRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,13 +24,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class BlogServiceTest {
 
   @Mock private BlogRepository blogRepository;
+  @Mock private LikeRepository likeRepository;
 
   private BlogService blogService;
 
   @BeforeEach
   void setup() {
     MockitoAnnotations.openMocks(this);
-    blogService = new BlogService(blogRepository, null, null);
+    blogService = new BlogService(blogRepository, null, null, likeRepository);
   }
 
   @Test
@@ -49,6 +51,7 @@ class BlogServiceTest {
     blog.setAuthor(author);
 
     when(blogRepository.findById(blogId)).thenReturn(Optional.of(blog));
+    when(likeRepository.countByBlog_Id(blogId)).thenReturn(0L);
 
     // When
     BlogResponseDto result = blogService.getById(blogId);
@@ -77,6 +80,7 @@ class BlogServiceTest {
     blog.setAuthor(author);
 
     when(blogRepository.findById(blogId)).thenReturn(Optional.of(blog));
+    when(likeRepository.countByBlog_Id(blogId)).thenReturn(0L);
 
     // When
     blogService.getById(blogId);


### PR DESCRIPTION
Feature: Like System for Blog Posts
New Files Created

### **1. model/Like.java**

New JPA entity representing a user's like on a blog post

@ManyToOne relationships to both User and Blog with FetchType.LAZY

Unique constraint uk_user_blog_like on (user_id, blog_id) to enforce one-like-per-user at DB level

Named foreign keys fk_like_user and fk_like_blog for schema clarity

createdAt timestamp auto-set by Hibernate via @CreationTimestamp

Table named likes to avoid SQL reserved keyword conflict with LIKE

### **2. repository/LikeRepository.java**

Spring Data JPA repository for Like entity

existsByUser_IdAndBlog_Id — checks if a like exists (happy path guard)

deleteByUser_IdAndBlog_Id — removes a like row directly without loading the entity

countByBlog_Id — returns total like count via COUNT query

findAllByBlog_Id — returns paginated list of likes for a blog

**### 3. dto/response/LikeResponseDto.java**

DTO holding likeCount (always present) and likedUsers (optional, nullable)

Reuses existing UserSummaryDto for the likers list — keeps payload minimal

@Nullable likedUsers only populated on explicit request, not on every blog fetch

### **4. service/LikeService.java**

Implements SecurityAwareService for JWT-based current user resolution

addLike — idempotent, double-guarded with existsBy check + DataIntegrityViolationException catch for race conditions

removeLike — deletes like row directly, no-op if not liked

toggle — returns true if liked, false if unliked

isLiked — read-only check for current user

getLikeCount — read-only COUNT query

getLikes — returns LikeResponseDto with count + paginated likers list

Uses EntityManager.getReference() to avoid extra SELECT on User table during insert

### **5. controller/LikeController.java**

POST /api/likes/{blogId} — like a post

DELETE /api/likes/{blogId} — unlike a post

POST /api/likes/{blogId}/toggle — toggle like status

GET /api/likes/check?blogId= — check if current user liked a post

GET /api/likes/{blogId}?page=0&size=20 — get like count + likers list

All endpoints secured via existing anyRequest().authenticated() in SecurityConfig — no config change needed

Modified Files
### **6. dto/response/BlogResponseDto.java**

Added Long likeCount field as the last field

Included in standard blog responses so clients always receive like count

### **7. mapper/BlogMapper.java**

Added overloaded toDto(Blog blog, long likeCount) method

Original toDto(Blog blog) kept with 0L default for backward compatibility with existing call sites

New overload accepts precomputed likeCount from LikeRepository — keeps mapper as a pure static utility, no Spring bean needed

### **8. service/BlogService.java**

Injected LikeRepository as a new final field

getById() updated to call BlogMapper.toDto(blog, likeRepository.countByBlog_Id(blog.getId())) — returns accurate like count

### **9. service/BookmarkService.java**

Injected LikeRepository as a new final field

listMyBookmarks() updated to pass like count when mapping bookmark blogs to DTOs

Test Fixes
### **10. test/mapper/UserMapperTest.java**

Replaced import static org.junit.jupiter.api.Assertions.* with explicit imports (Checkstyle fix)

Fixed testToResponseDtoMapsAllFields — assertions were checking stale @BeforeEach values instead of the values set in the test's Arrange block

### **11. test/controller/UserControllerTest.java**

Replaced star imports with explicit imports (Checkstyle fix)

Fixed all record-style accessor calls (result.id()) to Lombok getter style (result.getId()) since UserResponseDto uses @Value not a Java record

### **12. test/service/UserServiceTest.java**

Fixed testGetCurrentUserProfileSuccess — assertions were checking wrong hardcoded values (john_doe, John, etc.) instead of the user set up in that test (testuser, Test, etc.)

Fixed mockSecurityContextNull — removed broken try (var ignored = mockStatic(...)) wrapper that was closing the static mock before the actual service call, causing the null authentication to never be seen

Removed unused mockStatic import

### **13. test/service/BlogServiceTest.java**

Added @Mock LikeRepository likeRepository field

Updated constructor call from new BlogService(blogRepository, null, null) to new BlogService(blogRepository, null, null, likeRepository) — required after LikeRepository was added as 4th field

Added when(likeRepository.countByBlog_Id(blogId)).thenReturn(0L) stub in both tests to prevent NullPointerException