### PR TITLE
docs: add OpenAPI operation summaries to controllers

### DIFF
--- a/src/main/java/com/huseynovvusal/springblogapi/controller/AdminController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/AdminController.java
@@ -3,6 +3,7 @@ package com.huseynovvusal.springblogapi.controller;
 import com.huseynovvusal.springblogapi.dto.BlockUserRequest;
 import com.huseynovvusal.springblogapi.dto.BlockUserResponse;
 import com.huseynovvusal.springblogapi.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,9 @@ public class AdminController {
   private static final Logger LOGGER = LoggerFactory.getLogger(AdminController.class);
   private final UserService userService;
 
+  @Operation(
+      summary = "Change user block status",
+      description = "Blocks or unblocks a user account based on the requested status.")
   @PostMapping("block-user")
   public BlockUserResponse changeBlockStatus(@Valid @RequestBody BlockUserRequest request) {
     LOGGER.info("Changing Block Status for: {}", request.getUsername());

--- a/src/main/java/com/huseynovvusal/springblogapi/controller/AuthenticationController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/AuthenticationController.java
@@ -13,6 +13,7 @@ import com.huseynovvusal.springblogapi.exception.InvalidRefreshTokenException;
 import com.huseynovvusal.springblogapi.exception.UserAlreadyRegisteredException;
 import com.huseynovvusal.springblogapi.service.AuthenticationService;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -41,6 +42,9 @@ public class AuthenticationController {
    * @return a response entity with registration status and user info
    * @throws UserAlreadyRegisteredException
    */
+  @Operation(
+      summary = "Register a new user",
+      description = "Creates a new account and returns registration details.")
   @PostMapping("register")
   @RateLimiter(name = "auth")
   public RegisterResponse register(@Valid @RequestBody RegisterRequest request)
@@ -58,6 +62,9 @@ public class AuthenticationController {
    * @param request the login request containing username and password
    * @return a response entity with authentication token and user info
    */
+  @Operation(
+      summary = "Log in a user",
+      description = "Authenticates a user and returns access credentials.")
   @PostMapping("login")
   @RateLimiter(name = "auth")
   public LoginResponse login(@Valid @RequestBody LoginRequest request) {
@@ -74,6 +81,9 @@ public class AuthenticationController {
    * @param request the forgot password request containing the user's email
    * @return a response entity with token generation status
    */
+  @Operation(
+      summary = "Request password reset",
+      description = "Generates a password reset token and sends it to the user's email.")
   @PostMapping("forgot-password")
   public ForgotPasswordResponse getPasswordResetLink(
       @Valid @RequestBody ForgotPasswordRequest request) {
@@ -90,6 +100,9 @@ public class AuthenticationController {
    * @param request the reset password request containing token and new password
    * @return a response entity with password reset status
    */
+  @Operation(
+      summary = "Reset password",
+      description = "Verifies the password reset token and updates the user's password.")
   @PostMapping("reset-password")
   public ResetPasswordResponse resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
     LOGGER.info("Password reset attempt with token: {}", request.getToken());
@@ -104,6 +117,9 @@ public class AuthenticationController {
    *
    * @throws InvalidRefreshTokenException
    */
+  @Operation(
+      summary = "Refresh tokens",
+      description = "Rotates a valid refresh token into new access and refresh tokens.")
   @PostMapping("refresh")
   @RateLimiter(name = "auth")
   public LoginResponse refresh(@Valid @RequestBody RefreshTokenRequest request)

--- a/src/main/java/com/huseynovvusal/springblogapi/controller/BlogController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/BlogController.java
@@ -43,6 +43,9 @@ public class BlogController {
    * @param pageable pagination and sorting information
    * @return paginated list of blog responses
    */
+  @Operation(
+      summary = "List blog posts",
+      description = "Retrieves a paginated list of all blogs sorted by creation date.")
   @GetMapping
   public Page<BlogResponseDto> getAllBlogs(
       @PageableDefault(
@@ -60,6 +63,7 @@ public class BlogController {
    * @param id the blog ID
    * @return the blog response
    */
+  @Operation(summary = "Get blog post", description = "Retrieves a blog by its unique ID.")
   @GetMapping("/{id}")
   @RateLimiter(name = "default")
   public BlogResponseDto getById(@PathVariable Long id) {
@@ -74,6 +78,9 @@ public class BlogController {
    * @param pageable pagination and sorting information
    * @return paginated list of blog responses
    */
+  @Operation(
+      summary = "List blogs by author",
+      description = "Retrieves paginated blogs authored by a specific user.")
   @GetMapping("/author/{username}")
   public Page<BlogResponseDto> getByAuthor(
       @PathVariable String username,
@@ -92,6 +99,7 @@ public class BlogController {
    * @param body the blog creation request
    * @return the created blog response
    */
+  @Operation(summary = "Create blog post", description = "Creates a new blog post.")
   @PostMapping
   public BlogResponseDto create(@Valid @RequestBody CreateBlog body) {
     LOGGER.info("Creating new blog with title: {}", body.getTitle());
@@ -110,6 +118,9 @@ public class BlogController {
    * @param pageable pagination information
    * @return paginated list of filtered blog responses
    */
+  @Operation(
+      summary = "Filter blog posts",
+      description = "Filters blogs by tags, author, creation date, query, and publication status.")
   @GetMapping("/filter")
   public Page<BlogResponseDto> filter(
       @RequestParam(required = false) List<String> tags,

--- a/src/main/java/com/huseynovvusal/springblogapi/controller/BookmarkController.java
+++ b/src/main/java/com/huseynovvusal/springblogapi/controller/BookmarkController.java
@@ -3,6 +3,7 @@ package com.huseynovvusal.springblogapi.controller;
 import com.huseynovvusal.springblogapi.dto.response.BlogResponseDto;
 import com.huseynovvusal.springblogapi.exception.BlogNotFoundException;
 import com.huseynovvusal.springblogapi.service.BookmarkService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -37,6 +38,9 @@ public class BookmarkController {
    * @return HTTP 204 No Content on success
    * @throws BlogNotFoundException
    */
+  @Operation(
+      summary = "Add bookmark",
+      description = "Adds a bookmark for the specified blog for the current user.")
   @PostMapping("/{blogId}")
   public void add(@PathVariable Long blogId) throws BlogNotFoundException {
     LOGGER.info("Adding bookmark for blog ID: {}", blogId);
@@ -49,6 +53,9 @@ public class BookmarkController {
    * @param blogId the ID of the blog to unbookmark
    * @return HTTP 204 No Content on success
    */
+  @Operation(
+      summary = "Remove bookmark",
+      description = "Removes a bookmark for the specified blog for the current user.")
   @DeleteMapping("/{blogId}")
   public void remove(@PathVariable Long blogId) {
     LOGGER.info("Removing bookmark for blog ID: {}", blogId);
@@ -61,6 +68,9 @@ public class BookmarkController {
    * @param blogId the ID of the blog to check
    * @return true if bookmarked, false otherwise
    */
+  @Operation(
+      summary = "Check bookmark",
+      description = "Checks whether the specified blog is bookmarked by the current user.")
   @GetMapping("/check")
   public boolean isBookmarked(@RequestParam Long blogId) {
     LOGGER.info("Checking bookmark status for blog ID: {}", blogId);
@@ -76,6 +86,9 @@ public class BookmarkController {
    * @return true if now bookmarked, false if removed
    * @throws BlogNotFoundException
    */
+  @Operation(
+      summary = "Toggle bookmark",
+      description = "Toggles the bookmark status for the specified blog.")
   @PostMapping("/{blogId}/toggle")
   public boolean toggle(@PathVariable Long blogId) throws BlogNotFoundException {
     LOGGER.info("Toggling bookmark for blog ID: {}", blogId);
@@ -91,6 +104,9 @@ public class BookmarkController {
    * @param size the page size (default 20)
    * @return paginated list of bookmarked blogs
    */
+  @Operation(
+      summary = "List bookmarks",
+      description = "Lists the current user's bookmarked blogs with pagination.")
   @GetMapping
   public Page<BlogResponseDto> list(
       @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "20") int size) {


### PR DESCRIPTION
## Summary
- Added OpenAPI `@Operation` summaries and descriptions to public controller endpoints.
- Covered Authentication, Blog, Bookmark, and Admin controller endpoints from issue #83.
- Kept endpoint behavior unchanged.

Closes #83