### PR TITLE
Add unit tests for BlogService (#76)

### DIFF
--- a/src/test/java/com/huseynovvusal/springblogapi/service/BlogServiceTest.java
+++ b/src/test/java/com/huseynovvusal/springblogapi/service/BlogServiceTest.java
@@ -1,23 +1,34 @@
 package com.huseynovvusal.springblogapi.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.huseynovvusal.springblogapi.dto.CreateBlog;
 import com.huseynovvusal.springblogapi.dto.response.BlogResponseDto;
 import com.huseynovvusal.springblogapi.model.Blog;
 import com.huseynovvusal.springblogapi.model.User;
 import com.huseynovvusal.springblogapi.repository.BlogRepository;
 import com.huseynovvusal.springblogapi.repository.LikeRepository;
+import com.huseynovvusal.springblogapi.security.RichTextSanitizer;
+import java.time.Instant;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("BlogService Unit Tests")
@@ -25,13 +36,14 @@ class BlogServiceTest {
 
   @Mock private BlogRepository blogRepository;
   @Mock private LikeRepository likeRepository;
+  @Mock private UserService userService;
+  @Mock private RichTextSanitizer richTextSanitizer;
 
   private BlogService blogService;
 
   @BeforeEach
   void setup() {
-    MockitoAnnotations.openMocks(this);
-    blogService = new BlogService(blogRepository, null, null, likeRepository);
+    blogService = new BlogService(blogRepository, userService, richTextSanitizer, likeRepository);
   }
 
   @Test
@@ -87,5 +99,169 @@ class BlogServiceTest {
 
     // Then
     verify(blogRepository).incrementViews(eq(blogId));
+  }
+
+  @Test
+  @DisplayName("should throw NoSuchElementException when blog does not exist")
+  void shouldThrowWhenBlogNotFound() {
+    // Given
+    Long blogId = 99L;
+    when(blogRepository.findById(blogId)).thenReturn(Optional.empty());
+
+    // When / Then
+    assertThrows(NoSuchElementException.class, () -> blogService.getById(blogId));
+    verify(blogRepository).incrementViews(eq(blogId));
+  }
+
+  @Test
+  @DisplayName("should create a blog with sanitized content unchanged")
+  void shouldCreateBlogWhenContentUnchanged() {
+    // Given
+    CreateBlog request = new CreateBlog("Testing Valid Title", "Testing Content");
+
+    User currentUser = new User();
+    currentUser.setId(1L);
+    currentUser.setUsername("testuser");
+
+    when(userService.getCurrentUser()).thenReturn(currentUser);
+    when(richTextSanitizer.sanitize("Testing Content")).thenReturn("Testing Content");
+    when(blogRepository.save(any(Blog.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(likeRepository.countByBlog_Id(any())).thenReturn(0L);
+
+    // When
+    BlogResponseDto result = blogService.create(request);
+
+    // Then
+    assertThat(result.getContent()).isEqualTo("Testing Content");
+    assertThat(result.getTitle()).isEqualTo("Testing Valid Title");
+    verify(userService).getCurrentUser();
+    verify(richTextSanitizer).sanitize("Testing Content");
+    verify(blogRepository).save(any(Blog.class));
+  }
+
+  @Test
+  @DisplayName("should create a blog with sanitized content when sanitizer modifies input")
+  void shouldCreateBlogWithSanitizedContent() {
+    // Given
+    CreateBlog request = new CreateBlog("Testing Valid Title", "<script>Testing Content</script>");
+
+    User currentUser = new User();
+    currentUser.setId(1L);
+    currentUser.setUsername("testuser");
+
+    when(userService.getCurrentUser()).thenReturn(currentUser);
+    when(richTextSanitizer.sanitize("<script>Testing Content</script>"))
+        .thenReturn("Testing Content");
+    when(blogRepository.save(any(Blog.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(likeRepository.countByBlog_Id(any())).thenReturn(0L);
+
+    // When
+    BlogResponseDto result = blogService.create(request);
+
+    // Then
+    assertThat(result.getContent()).isEqualTo("Testing Content");
+    assertThat(result.getContent()).doesNotContain("<script>");
+    verify(richTextSanitizer).sanitize("<script>Testing Content</script>");
+    verify(blogRepository).save(any(Blog.class));
+  }
+
+  @Test
+  @DisplayName("should return blogs by author")
+  void shouldReturnBlogsByAuthor() {
+    // Given
+    String username = "testuser";
+    Pageable pageable = PageRequest.of(0, 10);
+
+    User author = new User();
+    author.setId(1L);
+    author.setUsername(username);
+
+    Blog blog = new Blog();
+    blog.setId(1L);
+    blog.setTitle("Author's Blog");
+    blog.setContent("Some content");
+    blog.setAuthor(author);
+
+    Page<Blog> blogPage = new PageImpl<>(List.of(blog), pageable, 1);
+
+    when(userService.getUserByUsername(username)).thenReturn(author);
+    when(blogRepository.findByAuthor(author, pageable)).thenReturn(blogPage);
+    when(likeRepository.countByBlog_Id(any())).thenReturn(0L);
+
+    // When
+    Page<BlogResponseDto> result = blogService.getByAuthor(username, pageable);
+
+    // Then
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().getFirst().getTitle()).isEqualTo("Author's Blog");
+    verify(userService).getUserByUsername(username);
+    verify(blogRepository).findByAuthor(author, pageable);
+  }
+
+  @Test
+  @DisplayName("should return filtered results")
+  void shouldReturnFilteredResults() {
+    // Given
+    List<String> tags = List.of("java");
+    String authorUsername = "testuser";
+    Instant createdFrom = Instant.EPOCH;
+    Instant createdTo = Instant.now();
+    String query = "spring";
+    Pageable pageable = PageRequest.of(0, 10);
+
+    User author = new User();
+    author.setId(1L);
+    author.setUsername(authorUsername);
+
+    Blog blog = new Blog();
+    blog.setId(1L);
+    blog.setTitle("Spring Boot Guide");
+    blog.setContent("Some content");
+    blog.setAuthor(author);
+
+    Page<Blog> blogPage = new PageImpl<>(List.of(blog), pageable, 1);
+
+    when(blogRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(blogPage);
+    when(likeRepository.countByBlog_Id(any())).thenReturn(0L);
+
+    // When
+    Page<BlogResponseDto> result =
+        blogService.filter(tags, authorUsername, createdFrom, createdTo, query, null, pageable);
+
+    // Then
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().getFirst().getTitle()).isEqualTo("Spring Boot Guide");
+    verify(blogRepository).findAll(any(Specification.class), eq(pageable));
+  }
+
+  @Test
+  @DisplayName("should return search results")
+  void shouldReturnSearchResults() {
+    // Given
+    String query = "spring";
+    Pageable pageable = PageRequest.of(0, 10);
+
+    User author = new User();
+    author.setId(1L);
+    author.setUsername("testuser");
+
+    Blog blog = new Blog();
+    blog.setId(1L);
+    blog.setTitle("Spring Boot Guide");
+    blog.setContent("Some content");
+    blog.setAuthor(author);
+
+    Page<Blog> blogPage = new PageImpl<>(List.of(blog), pageable, 1);
+
+    when(blogRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(blogPage);
+    when(likeRepository.countByBlog_Id(any())).thenReturn(0L);
+
+    // When
+    Page<BlogResponseDto> result = blogService.search(query, pageable);
+
+    // Then
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().getFirst().getTitle()).isEqualTo("Spring Boot Guide");
+    verify(blogRepository).findAll(any(Specification.class), eq(pageable));
   }
 }


### PR DESCRIPTION
Closes #76

Adds `BlogServiceTest.java` with unit tests covering the acceptance criteria, using Mockito with `BlogRepository`, `UserService`, `RichTextSanitizer`, and `LikeRepository` fully mocked (no Spring context, no database).

**Covered:**
- `getById` - returns mapped DTO when blog exists
- `getById` - throws `NoSuchElementException` when blog is missing
- `create` - saves blog for current user, content passed through `RichTextSanitizer` (two variants: unchanged content, and sanitizer actively stripping unsafe input)
- `getByAuthor` - resolves author via `UserService`, returns mapped page
- `search` - mapped page, happy-path
- `filter` - mapped page, happy-path

**Note:** the issue's example constructor snippet (`blogRepository, userService, richTextSanitizer`) is out of date, `BlogService`'s actual constructor takes a 4th dependency, `LikeRepository`, via Lombok's `@RequiredArgsConstructor`. Tests are written against the current constructor.

Confirmed `./gradlew check` passes locally (build, tests, Spotless, Checkstyle).

This is my first open source contribution, happy to take feedback on style/structure and push follow-up commits to this branch. **Also worth noting I wasn't formally assigned #76 (noticed a few others expressed interest too), glad to step back if it's already spoken for.**